### PR TITLE
fix for moving funds to stake contract via proxy contract

### DIFF
--- a/contracts/proxy.scilla
+++ b/contracts/proxy.scilla
@@ -153,7 +153,7 @@ end
 (* @dev: Moves an amount tokens from _sender to the recipient. Used by token_owner. i.e. ssn *)
 (* @dev: Stake amount of exisitng ssn in ssnlist will be updated with new amount only if existing stake amount is 0.
          Balance of contract account will increase. Balance of _sender will decrease.      *)
-transition stake_deposit (initiator: ByStr20)
+transition stake_deposit ()
     current_impl <- implementation;
     accept;
     msg = {_tag : "stake_deposit"; _recipient : current_impl; _amount : _amount; initiator : _sender};

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -252,7 +252,7 @@ transition update_verifier (verif : ByStr20, initiator: ByStr20)
   verifier := newverifier
 end
 
-(* @dev: Set the admin of contract. Used by current admin only. *)
+(* @dev: Drain the entire contract balance. Used by current admin only. *)
 (* @param initiator: The original caller who called the proxy *)
 transition drain_contract_balance (initiator : ByStr20)
   validate_proxy;


### PR DESCRIPTION
transition in proxy.scilla `deposit_funds` and `stake_deposit` causes funds to be transferred from proxy balance to stake balance instead of moving funds from caller account.

So now first we accept money in proxy contract and then send money out from proxy to stake contract.
If for some reason, money is not supposed to be accepted by stake contract, we still accept it from proxy but we transfer back the amount to initiator i.e. original caller of transition in proxy.