### PR TITLE
feat: change deposit_funds into AddFunds

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Each of these category of transitions are presented in further detail below.
 | `assign_stake_reward` | `ssnreward_list : List SsnRewardShare, reward_blocknum : Uint32, initiator : ByStr20` | To assign rewards to the SSNs based on their performance. Performance checks happen off the chain. <br>  :warning: **Note:** `initiator` must be the current `verifier` of the contract. | <center>:x:</center> |
 | `withdraw_stake_rewards` | `initiator : ByStr20` | A registered SSN (`initiator`) can call this transition to withdraw its stake rewards. Stake rewards represent the rewards that an SSN has earned based on its performance. If the SSN has already withdrawn its deposit, then the SSN is removed. | <center>:x:</center> |
 | `withdraw_stake_amount` | `amount : Uint128, initiator : ByStr20` | A registered SSN (`initiator`) can call this transition to withdraw its deposit. The amount to be withdrawn is the input value `amount`. Stake amount represents the deposit that an SSN has made so far.   <br> :warning: **Note:** <ul><li> Any partial withdrawal should ensure that the remaining deposit is greater than `min_stake`. Partial withdrawals that push the deposit amount to be lower than `min_stake` are denied. </li> <li> In case there is a non-zero buffereddeposit, withdrawal is denied. </li> <li> If the withdrawal is for the entire deposit but rewards have not been fully withdrawn, then the SSN becomes inactive. </li> <li> If the withdrawal is for the entire deposit and if the rewards have also been withdrawn, then the SSN is removed. </li> </ul>  | <center>:x:</center> |
-| `deposit_funds` | `initiator : ByStr20` | Deposit ZILs into the contract.  | <center>:x:</center> |
+| `AddFunds` | `initiator : ByStr20` | Deposit ZILs into the contract.  | <center>:x:</center> |
 
 >**Note:** `Ssn` custom ADT has a field status of type `Bool`: `True` representing an active SSN. The value of this field depends on whether or not the amount staked by this SSN and the rewards held by this SSN are zero. The table below presents the different possible configurations and the value of the status field for each configuration. Note that when both the staked amount is zero and the reward is zero, the SSN is removed. <br>
 >| Staked Amount Value | Reward Amount Value | SSN Status |
@@ -220,7 +220,7 @@ These transitions are meant to redirect calls to the corresponding `SSNList` con
 |`assign_stake_reward (ssnreward_list : List SsnRewardShare, reward_blocknum : Uint32)` | `assign_stake_reward (ssnreward_list : List SsnRewardShare, reward_blocknum : Uint32, initiator: ByStr20)`|
 |`withdraw_stake_rewards()` | `withdraw_stake_rewards (initiator : ByStr20)`|
 |`withdraw_stake_amount (amount : Uint128)` | `withdraw_stake_amount (amount : Uint128, initiator: ByStr20)`|
-|`deposit_funds()` | `deposit_funds (initiator : ByStr20)`|
+|`AddFunds()` | `AddFunds (initiator : ByStr20)`|
 
 # Multi-signature Wallet Contract Specification
 

--- a/contracts/proxy.scilla
+++ b/contracts/proxy.scilla
@@ -190,10 +190,10 @@ transition withdraw_stake_amount (amount : Uint128 )
 end
 
 (* @dev: Move token amount from _sender to recipient i.e. contract address. *)
-transition deposit_funds ()
+transition AddFunds ()
     current_impl <- implementation;
     accept;
-    msg = {_tag : "deposit_funds"; _recipient : current_impl; _amount : _amount; initiator : _sender};
+    msg = {_tag : "AddFunds"; _recipient : current_impl; _amount : _amount; initiator : _sender};
     msgs = one_msg msg;
     send msgs
 end

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -89,9 +89,9 @@ let mk_withdraw_stake_rewards_event =
   fun (total_reward: Uint128) =>
     { _eventname : "SSN withdraw reward"; ssn_address : ssn; withdraw_total_reward : total_reward }
 
- let mk_deposit_funds_event =
+ let mk_add_funds_event =
   fun (sender : ByStr20) =>
-    { _eventname : "Verifier deposit funds"; verifier : sender }
+    { _eventname : "Verifier add funds"; verifier : sender }
 
  let mk_withdraw_below_stake_limit_event =
     fun (ssn : ByStr20) =>
@@ -528,10 +528,10 @@ end
 
 (* @dev: Move token amount from initiator to recipient i.e. contract address. *)
 (* @param initiator: The original caller who called the proxy *)
-transition deposit_funds (initiator : ByStr20)
+transition AddFunds (initiator : ByStr20)
   is_paused;
   validate_proxy;
   accept;
-  e = mk_deposit_funds_event initiator;
+  e = mk_add_funds_event initiator;
   event e
 end


### PR DESCRIPTION
This PR change `deposit_funds` transition name into `AddFunds`. Moving forward, we are going to introduce a new ZRC to standardize `AddFunds` transition for receiving $ZIL. As such this is a move to conform to this upcoming ZRC. 

**Note: This is a breaking change**