### PR TITLE
fix: total stake deposit calculation

### DIFF
--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -421,8 +421,9 @@ transition remove_ssn (ssnaddr : ByStr20, initiator: ByStr20)
     TransferFunds add_funds_tag funds ssnaddr;
     delete ssnlist[ssnaddr];
     totalstakedeposit_l <- totalstakedeposit;
-    totalstakedeposit_l = builtin sub totalstakedeposit_l stake_amount;
-    totalstakedeposit := totalstakedeposit_l;
+    deposit_amount = builtin add stake_amount buffereddeposit;
+    tmp = builtin sub totalstakedeposit_l deposit_amount;
+    totalstakedeposit := tmp;
     e = mk_ssn_removed_event ssnaddr;
     event e
   | None =>

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -475,7 +475,7 @@ transition stake_deposit (initiator: ByStr20)
           e = mk_total_stake_deposit_above_contract_stake_limit_error initiator new_stake_amount contractmaxstake_l;
           throw e
         | False =>
-          (* Check if its first time deposit *)
+          (* Check if its first time deposit or redeposit of stake after withdrawal of all stake *)
           pass = builtin eq stake_amount uint128_zero;
           match pass with
           | True =>

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -394,7 +394,8 @@ transition add_ssn_after_upgrade (ssnaddr : ByStr20, stake_amount : Uint128, rew
       | False =>
         (* Update the total stake deposit *)
         totalstakedeposit_l <- totalstakedeposit;
-        totalstakedeposit_l = builtin add totalstakedeposit_l stake_amount;
+        deposit_amount = builtin add stake_amount buffered_deposit;
+        totalstakedeposit_l = builtin add totalstakedeposit_l deposit_amount;
         totalstakedeposit := totalstakedeposit_l
       end;
       s = Ssn status stake_amount rewards urlraw urlapi buffered_deposit;

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -393,10 +393,10 @@ transition add_ssn_after_upgrade (ssnaddr : ByStr20, stake_amount : Uint128, rew
       | True =>
       | False =>
         (* Update the total stake deposit *)
-        totalstakedeposit_l <- totalstakedeposit;
+        temp_total_stake_deposit <- totalstakedeposit;
         deposit_amount = builtin add stake_amount buffered_deposit;
-        totalstakedeposit_l = builtin add totalstakedeposit_l deposit_amount;
-        totalstakedeposit := totalstakedeposit_l
+        new_total_stake_deposit = builtin add temp_total_stake_deposit deposit_amount;
+        totalstakedeposit := new_total_stake_deposit
       end;
       s = Ssn status stake_amount rewards urlraw urlapi buffered_deposit;
       ssnlist[ssnaddr] := s

--- a/tests/main/main.go
+++ b/tests/main/main.go
@@ -77,6 +77,8 @@ func main() {
 	transitions.TestAssignStakeReward(pri1, pri2, api)
 
 	transitions.TestWithdrawAmount(pri1, pri2, api)
+	
+	transitions.TestRemoveSSN(pri1,pri2,api)
 
 	endTime := time.Now()
 	interval := endTime.Sub(fromTime).Minutes()

--- a/tests/transitions/assign_stake_reward.go
+++ b/tests/transitions/assign_stake_reward.go
@@ -79,7 +79,7 @@ func TestAssignStakeReward(pri1, pri2, api string) {
 		{
 			VName: "buffered_deposit",
 			Type:  "Uint128",
-			Value: "0",
+			Value: "1000",
 		},
 	}
 	args, _ := json.Marshal(parameters)
@@ -156,12 +156,19 @@ func TestAssignStakeReward(pri1, pri2, api string) {
 		}
 	}
 
+	// check totalstakedeposit
+	res := p.Provider.GetSmartContractState(p.ImplAddress).Result.(map[string]interface{})
+	totalstakedeposit := res["totalstakedeposit"].(string)
+	if totalstakedeposit != "200000001000" {
+		panic("check totalstakedeposit error")
+	}
+
 	// 3. reward ssn1
 	err = p.assignStakeReward(pri1, ssn1, "50")
 	if err != nil {
 		panic("reward ssn1 failed: " + err.Error())
 	}
-	res := p.Provider.GetSmartContractState(p.ImplAddress).Result.(map[string]interface{})
+	res = p.Provider.GetSmartContractState(p.ImplAddress).Result.(map[string]interface{})
 	sshmap := res["ssnlist"].(map[string]interface{})
 	ssn := sshmap[ssn1]
 	if ssn == nil {

--- a/tests/transitions/remove_ssn.go
+++ b/tests/transitions/remove_ssn.go
@@ -1,0 +1,214 @@
+//
+// test: remove_deposit
+//
+package transitions
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/Zilliqa/gozilliqa-sdk/keytools"
+	"github.com/Zilliqa/gozilliqa-sdk/util"
+
+	"github.com/Zilliqa/gozilliqa-sdk/bech32"
+	contract2 "github.com/Zilliqa/gozilliqa-sdk/contract"
+)
+
+
+func TestRemoveSSN(pri1, pri2 string, api string) {
+	fmt.Println("------------------------ start remove ssn ------------------------")
+	err, proxy, impl := DeployAndUpgrade(pri1)
+	if err != nil {
+		panic("got error = " + err.Error())
+	}
+	fmt.Println("proxy = ", proxy)
+	fmt.Println("impl = ", impl)
+	p := NewProxy(api, proxy, impl)
+	p.RemoveSSN(pri1, pri2, api)
+}
+
+func (p *Proxy) RemoveSSN(pri1, pri2 string, api string) {
+	if err0 := p.unpause(pri1); err0 != nil {
+		panic("unpause with valid account failed")
+	}
+	// 0. setup minstake maxstake contractmaxstake
+	err := p.updateStakingParameter(pri1, strconv.Itoa(MIN_STAKE), strconv.Itoa(MAX_STAKE), strconv.Itoa(CONTRACT_MAX_STAKE))
+	if err != nil {
+		panic("update staking parameter error: " + err.Error())
+	}
+	err = p.updateVerifier(pri1)
+	if err != nil {
+		panic("update verifier error: " + err.Error())
+	}
+
+
+	// 1. add pri2 as ssn
+	ssnaddr := "0x" + keytools.GetAddressFromPrivateKey(util.DecodeHex(pri2))
+	p.RegisterSSN(pri1, ssnaddr)
+
+	proxy, _ := bech32.ToBech32Address(p.Addr)
+
+	// 2. as ssn, first time stake deposit (MIN_STAKE + 1)
+	if err3, output := ExecZli("contract", "call",
+		"-k", pri2,
+		"-a", proxy,
+		"-t", "stake_deposit",
+		"-m", strconv.Itoa(MIN_STAKE+1),
+		"-f", "true",
+		"-r", "[]"); err3 != nil {
+		panic("call transaction error: " + err3.Error())
+	} else {
+		tx := strings.TrimSpace(strings.Split(output, "confirmed!")[1])
+		fmt.Println("transaction id = ", tx)
+		payload := p.Provider.GetTransaction(tx).Result.(map[string]interface{})
+		receipt := payload["receipt"].(map[string]interface{})
+		success := receipt["success"].(bool)
+		eventLogs := receipt["event_logs"].([]interface{})[0]
+		if success {
+			events := eventLogs.(map[string]interface{})
+			eventName := events["_eventname"].(string)
+
+			if eventName == "SSN updated stake" {
+				ssnAddr := events["params"].([]interface{})[0].(map[string]interface{})["value"].(string)
+				newStakeAmount := events["params"].([]interface{})[1].(map[string]interface{})["value"].(string)
+				expectedSSNAddr := "0x" + keytools.GetAddressFromPrivateKey(util.DecodeHex(pri2))
+				expectedStakeAmount := strconv.Itoa(MIN_STAKE + 1)
+
+				if ssnAddr != expectedSSNAddr {
+					panic("test first time stake deposit failed, tx:" + tx + " , returned ssn: " + ssnAddr + " , expected ssn: " + expectedSSNAddr)
+				}
+				if newStakeAmount != expectedStakeAmount {
+					panic("test first time stake deposit failed, tx:" + tx + " , returned stake amount: " + newStakeAmount + " , expected stake amount: " + expectedStakeAmount)
+				}
+
+				// check ssn active status
+				res := p.Provider.GetSmartContractState(p.ImplAddress).Result.(map[string]interface{})
+				ssnmap := res["ssnlist"].(map[string]interface{})
+				ssn := ssnmap[ssnAddr]
+
+				if ssn == nil {
+					panic("test first time stake deposit failed, tx:" + tx)
+				} else {
+					ssnStatus := ssn.(map[string]interface{})["arguments"].([]interface{})[0].(map[string]interface{})["constructor"].(string)
+					if ssnStatus == "True" {
+						fmt.Println("test first time stake deposit succeed")
+					} else {
+						panic("test first time stake deposit failed, tx:" + tx)
+					}
+				}
+
+			} else {
+				panic("test first time stake deposit failed, tx:" + tx)
+			}
+		} else {
+			panic("test stake deposit below min stake limit error, tx:" + tx)
+		}
+	}
+
+	// 3. after first time deposit, deposit min_stake + 1
+	if err3, output := ExecZli("contract", "call",
+		"-k", pri2,
+		"-a", proxy,
+		"-t", "stake_deposit",
+		"-m", strconv.Itoa(MIN_STAKE+1),
+		"-f", "true",
+		"-r", "[]"); err3 != nil {
+		panic("call transaction error: " + err3.Error())
+	} else {
+		tx := strings.TrimSpace(strings.Split(output, "confirmed!")[1])
+		fmt.Println("transaction id = ", tx)
+		payload := p.Provider.GetTransaction(tx).Result.(map[string]interface{})
+		receipt := payload["receipt"].(map[string]interface{})
+		success := receipt["success"].(bool)
+		if success {
+			// no event output after the first time stake deposit
+			// check ssn active status
+			res := p.Provider.GetSmartContractState(p.ImplAddress).Result.(map[string]interface{})
+			totalStakeDeposit := res["totalstakedeposit"].(string)
+			expectedTotalStakeDeposit := strconv.Itoa((MIN_STAKE + 1) * 2)
+			ssnmap := res["ssnlist"].(map[string]interface{})
+			ssnAddr := "0x" + keytools.GetAddressFromPrivateKey(util.DecodeHex(pri2))
+			ssn := ssnmap[ssnAddr]
+
+			// this is the second time depositing (min stake + 1)
+			if totalStakeDeposit != expectedTotalStakeDeposit {
+				panic("test stake deposit (after first time deposit) failed, tx:" + tx + " , total stake deposit:" + totalStakeDeposit + " , expected:" + expectedTotalStakeDeposit)
+			}
+
+			if ssn == nil {
+				panic("test stake deposit (after first time deposit) error, tx:" + tx)
+			} else {
+				ssnStatus := ssn.(map[string]interface{})["arguments"].([]interface{})[0].(map[string]interface{})["constructor"].(string)
+				if ssnStatus == "True" {
+					fmt.Println("test stake deposit (after first time deposit) succeed")
+				} else {
+					panic("test stake deposit (after first time deposit) error, tx:" + tx)
+				}
+			}
+
+		} else {
+			panic("test stake deposit (after first time deposit) error, tx:" + tx)
+		}
+	}
+
+	res := p.Provider.GetSmartContractState(p.ImplAddress).Result.(map[string]interface{})
+	r, _ := json.Marshal(res)
+	fmt.Println("before removing: ",string(r))
+
+
+    // 4.6 remove ssn
+	m := p.Provider.GetBalance(p.ImplAddress).Result.(map[string]interface{})
+	before := m["balance"].(string)
+	fmt.Println("balance bofore removing ssn: ",before)
+
+	// 4.2 remove exist ssn
+	parameters := []contract2.Value{
+		{
+			VName: "ssnaddr",
+			Type:  "ByStr20",
+			Value: ssnaddr,
+		},
+	}
+	args, _ := json.Marshal(parameters)
+	if err3, output := ExecZli("contract", "call",
+		"-k", pri1,
+		"-a", proxy,
+		"-t", "remove_ssn",
+		"-f", "true",
+		"-r", string(args)); err3 != nil {
+		panic("call transaction error: " + err3.Error())
+	} else {
+		tx := strings.TrimSpace(strings.Split(output, "confirmed!")[1])
+		fmt.Println("transaction id = ", tx)
+		payload := p.Provider.GetTransaction(tx).Result.(map[string]interface{})
+		receipt := payload["receipt"].(map[string]interface{})
+		success := receipt["success"].(bool)
+		if success {
+			res := p.Provider.GetSmartContractState(p.ImplAddress).Result.(map[string]interface{})
+			r, _ = json.Marshal(res)
+			fmt.Println(string(r))
+			ssnList, _ := res["ssnlist"]
+			ssnMap := ssnList.(map[string]interface{})
+			ssn := ssnMap[ssnaddr]
+			totalstakedeposit := res["totalstakedeposit"].(string)
+			if ssn == nil && totalstakedeposit == "0" {
+				m = p.Provider.GetBalance(p.ImplAddress).Result.(map[string]interface{})
+				after := m["balance"].(string)
+				if after != "0" {
+					panic("check balance failed")
+				}
+
+			} else {
+				fmt.Println("test remove ssn failed: check state failed")
+			}
+
+		} else {
+			panic("test remove ssn failed")
+		}
+	}
+	
+	fmt.Println("------------------------ end remove ssn ------------------------")
+
+}


### PR DESCRIPTION
This PR is to fix mismatch for `totalstakedeposit`. The issue was caused by we didn't reduce buffered amount while doing `remove_ssn`.