### PR TITLE
Review of the staking contract

### DIFF
--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -154,6 +154,16 @@ type Ssn =
 type SsnRewardShare =
 | SsnRewardShare of ByStr20 Uint128
 
+let calculate_new_reward =
+  fun (stake : Uint128) =>
+  fun (reward_percentage : Uint128) =>
+  fun (old_reward : Uint128) =>
+    let hundred = Uint128 100 in
+    let stake_times_percentage = builtin mul stake reward_percentage in
+    let percentage_of_stake = builtin div stake_times_percentage hundred in
+    let additional_stake_fraction = builtin div percentage_of_stake uint128_10_power_7 in
+    builtin add additional_stake_fraction old_reward
+
 (***************************************************)
 (*             The contract definition             *)
 (***************************************************)
@@ -251,11 +261,7 @@ procedure update_stake_reward (entry : SsnRewardShare)
       e = mk_ssn_not_exists_error ssnaddr;
       throw e
     | Some (Ssn status stake_amount rewards buffereddeposit urlinfo) =>
-      hundred = Uint128 100;
-      new_reward = builtin mul stake_amount reward_percent;
-      new_reward = builtin div new_reward hundred;
-      new_reward = builtin div new_reward uint128_10_power_7;
-      total_reward = builtin add new_reward rewards;
+      total_reward = calculate_new_reward stake_amount reward_percent rewards;
       new_stake_amount = builtin add stake_amount buffereddeposit;
       ssn = Ssn status new_stake_amount total_reward uint128_zero urlinfo;
       ssnlist[ssnaddr] := ssn;

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -196,7 +196,7 @@ field paused : Bool = True
 
 (* Procedures *)
 (* Add/update key/value pair to ssn_list, and update size accordingly *)
-procedure add_to_ssn_list (key : ByStr20, value : Ssn)
+procedure add_to_ssn_list (key : ByStr20, status : ActiveStatus, stake_amount : Uint128, rewards : Uint128, buffered_deposit : Uint128, urlinfo : UrlInfo)
   already_exists <- exists ssnlist[key];
   match already_exists with
   | True =>
@@ -205,6 +205,7 @@ procedure add_to_ssn_list (key : ByStr20, value : Ssn)
     new_size = builtin add siz uint32_one;
     ssnlist_size := new_size
   end;
+  value = Ssn status stake_amount rewards buffered_deposit urlinfo;
   ssnlist[key] := value
 end
 
@@ -291,8 +292,7 @@ procedure update_stake_reward (entry : SsnRewardShare)
     | Some (Ssn status stake_amount rewards buffereddeposit urlinfo) =>
       total_reward = calculate_new_reward stake_amount reward_percent rewards;
       new_stake_amount = builtin add stake_amount buffereddeposit;
-      ssn = Ssn status new_stake_amount total_reward uint128_zero urlinfo;
-      add_to_ssn_list ssnaddr ssn;
+      add_to_ssn_list ssnaddr status new_stake_amount total_reward uint128_zero urlinfo;
       e = mk_assign_stake_reward_event ssnaddr total_reward;
       event e
     end
@@ -403,8 +403,7 @@ transition add_ssn (ssnaddr : ByStr20, urlraw : String, urlapi : String, initiat
       buffered_deposit = Uint128 0;
       rewards = Uint128 0;
       urlinfo = UrlInfo urlraw urlapi;
-      s = Ssn status stake_amount rewards buffered_deposit urlinfo;
-      add_to_ssn_list ssnaddr s;
+      add_to_ssn_list ssnaddr status stake_amount rewards buffered_deposit urlinfo;
       e = mk_ssn_added_event ssnaddr;
       event e      
     | False =>
@@ -449,8 +448,7 @@ transition add_ssn_after_upgrade (ssnaddr : ByStr20, stake_amount : Uint128, rew
         totalstakedeposit := totalstakedeposit_l
       end;
       urlinfo = UrlInfo urlraw urlapi;
-      s = Ssn status stake_amount rewards buffered_deposit urlinfo;
-      add_to_ssn_list ssnaddr s
+      add_to_ssn_list ssnaddr status stake_amount rewards buffered_deposit urlinfo
     | False =>
       e = mk_ssn_list_full_error initiator;
       throw e
@@ -529,14 +527,12 @@ transition stake_deposit (initiator: ByStr20)
           pass = builtin eq stake_amount uint128_zero;
           match pass with
           | True =>
-            ssn = Ssn const_active _amount rewards uint128_zero urlinfo;
-            add_to_ssn_list initiator ssn;
+            add_to_ssn_list initiator const_active _amount rewards uint128_zero urlinfo;
             e = mk_stake_deposit_event initiator _amount;
             event e
           | False =>
             (* Update new buffered deposit until next assign_stake_reward is finished *)
-            ssn = Ssn const_active stake_amount rewards new_buff_amount urlinfo;
-            add_to_ssn_list initiator ssn;
+            add_to_ssn_list initiator const_active stake_amount rewards new_buff_amount urlinfo;
             e = mk_stake_buffered_deposit_event initiator _amount;
             event e
           end;
@@ -579,8 +575,7 @@ transition withdraw_stake_rewards (initiator : ByStr20)
       remove_from_ssn_list initiator
     | False =>
       (* Update state to have 0 rewards. *)
-      ssn = Ssn status stake_amount uint128_zero buffereddeposit urlinfo;
-      add_to_ssn_list initiator ssn
+      add_to_ssn_list initiator status stake_amount uint128_zero buffereddeposit urlinfo
     end;
     TransferFunds add_funds_tag rewards initiator;
     e = mk_withdraw_stake_rewards_event initiator rewards;
@@ -618,8 +613,7 @@ transition withdraw_stake_amount (amount : Uint128, initiator: ByStr20)
             throw e
           | False => (* pass minstake check for withdrawal *)
             (* Update the stake amount *)
-            ssn = Ssn status bal_left rewards buffereddeposit urlinfo;
-            add_to_ssn_list initiator ssn;
+            add_to_ssn_list initiator status bal_left rewards buffereddeposit urlinfo;
             (* Update the total stake deposit with contract *)
             totalstakedeposit_l <- totalstakedeposit;
             tmp = builtin sub totalstakedeposit_l amount;
@@ -639,8 +633,7 @@ transition withdraw_stake_amount (amount : Uint128, initiator: ByStr20)
               (* entire stake withdrawed and also reward is withdrawed, so remove ssn *)
               remove_from_ssn_list initiator
             | False =>
-              ssn = Ssn const_inactive uint128_zero rewards buffereddeposit urlinfo;
-              add_to_ssn_list initiator ssn
+              add_to_ssn_list initiator const_inactive uint128_zero rewards buffereddeposit urlinfo
             end;
             totalstakedeposit_l <- totalstakedeposit;
             tmp = builtin sub totalstakedeposit_l amount;

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -128,7 +128,6 @@ let mk_withdraw_stake_rewards_event =
     fun (buffdeposit: Uint128) =>
       { _exception : "SSN withdrawal not allowed when some deposit is bufferred"; ssn_address : ssn; buffered_stake_amount : buffdeposit }
 
-(* Ssn - active_status , stake_amount, rewards, urlraw, urlapi, buffereddeposit *)
 type ActiveStatus =
 | Active
 | Inactive
@@ -143,8 +142,13 @@ let active_status_from_neg_bool =
     | False => const_active
     end
 
+(* UrlInfo - urlraw, urlapi *)
+type UrlInfo =
+| UrlInfo of String String
+
+(* Ssn - active_status , stake_amount, rewards, urlinfo, buffereddeposit *)
 type Ssn =
-| Ssn of ActiveStatus Uint128 Uint128 String String Uint128
+| Ssn of ActiveStatus Uint128 Uint128 Uint128 UrlInfo
 
 (* address reward_percentage *)
 type SsnRewardShare =
@@ -246,14 +250,14 @@ procedure update_stake_reward (entry : SsnRewardShare)
     | None =>
       e = mk_ssn_not_exists_error ssnaddr;
       throw e
-    | Some (Ssn status stake_amount rewards urlraw urlapi buffereddeposit) =>
+    | Some (Ssn status stake_amount rewards buffereddeposit urlinfo) =>
       hundred = Uint128 100;
       new_reward = builtin mul stake_amount reward_percent;
       new_reward = builtin div new_reward hundred;
       new_reward = builtin div new_reward uint128_10_power_7;
       total_reward = builtin add new_reward rewards;
       new_stake_amount = builtin add stake_amount buffereddeposit;
-      ssn = Ssn status new_stake_amount total_reward urlraw urlapi uint128_zero;
+      ssn = Ssn status new_stake_amount total_reward uint128_zero urlinfo;
       ssnlist[ssnaddr] := ssn;
       e = mk_assign_stake_reward_event ssnaddr total_reward;
       event e
@@ -365,7 +369,8 @@ transition add_ssn (ssnaddr : ByStr20, urlraw : String, urlapi : String, initiat
       status = const_inactive;
       buffered_deposit = Uint128 0;
       rewards = Uint128 0;
-      s = Ssn status stake_amount rewards urlraw urlapi buffered_deposit;
+      urlinfo = UrlInfo urlraw urlapi;
+      s = Ssn status stake_amount rewards buffered_deposit urlinfo;
       ssnlist[ssnaddr] := s;
       e = mk_ssn_added_event ssnaddr;
       event e      
@@ -411,7 +416,8 @@ transition add_ssn_after_upgrade (ssnaddr : ByStr20, stake_amount : Uint128, rew
         totalstakedeposit_l = builtin add totalstakedeposit_l stake_amount;
         totalstakedeposit := totalstakedeposit_l
       end;
-      s = Ssn status stake_amount rewards urlraw urlapi buffered_deposit;
+      urlinfo = UrlInfo urlraw urlapi;
+      s = Ssn status stake_amount rewards buffered_deposit urlinfo;
       ssnlist[ssnaddr] := s
     | False =>
       e = mk_ssn_list_full_error initiator;
@@ -429,7 +435,7 @@ transition remove_ssn (ssnaddr : ByStr20, initiator: ByStr20)
   validate_admin initiator;
   ssn_optional <- ssnlist[ssnaddr];
   match ssn_optional with
-  | Some (Ssn _ stake_amount rewards urlraw urlapi buffereddeposit) =>
+  | Some (Ssn _ stake_amount rewards buffereddeposit _) =>
     funds_temp = builtin add stake_amount rewards;
     funds = builtin add funds_temp buffereddeposit;
     TransferFunds add_funds_tag funds ssnaddr;
@@ -460,7 +466,7 @@ transition stake_deposit (initiator: ByStr20)
   | None =>
     e = mk_ssn_not_exists_error initiator;
     throw e
-  | Some (Ssn _ stake_amount rewards urlraw urlapi buffereddeposit) =>
+  | Some (Ssn _ stake_amount rewards buffereddeposit urlinfo) =>
     (* check if first non-zero deposit *)
     minstake_l <- minstake;
     maxstake_l <- maxstake;
@@ -491,13 +497,13 @@ transition stake_deposit (initiator: ByStr20)
           pass = builtin eq stake_amount uint128_zero;
           match pass with
           | True =>
-            ssn = Ssn const_active _amount rewards urlraw urlapi uint128_zero;
+            ssn = Ssn const_active _amount rewards uint128_zero urlinfo;
             ssnlist[initiator] := ssn;
             e = mk_stake_deposit_event initiator _amount;
             event e
           | False =>
             (* Update new buffered deposit until next assign_stake_reward is finished *)
-            ssn = Ssn const_active stake_amount rewards urlraw urlapi new_buff_amount;
+            ssn = Ssn const_active stake_amount rewards new_buff_amount urlinfo;
             ssnlist[initiator] := ssn;
             e = mk_stake_buffered_deposit_event initiator _amount;
             event e
@@ -532,7 +538,7 @@ transition withdraw_stake_rewards (initiator : ByStr20)
   | None =>
     e = mk_ssn_not_exists_error initiator;
     throw e
-  | Some (Ssn status stake_amount rewards urlraw urlapi buffereddeposit) =>
+  | Some (Ssn status stake_amount rewards buffereddeposit urlinfo) =>
     (* check if basic stake deposit is already withdrawn by ssn. If so, remove the ssn from list as well *)
     pass = builtin eq stake_amount uint128_zero;
     match pass with
@@ -541,7 +547,7 @@ transition withdraw_stake_rewards (initiator : ByStr20)
       delete ssnlist[initiator]
     | False =>
       (* Update state to have 0 rewards. *)
-      ssn = Ssn status stake_amount uint128_zero urlraw urlapi buffereddeposit;
+      ssn = Ssn status stake_amount uint128_zero buffereddeposit urlinfo;
       ssnlist[initiator] := ssn
     end;
     TransferFunds add_funds_tag rewards initiator;
@@ -561,7 +567,7 @@ transition withdraw_stake_amount (amount : Uint128, initiator: ByStr20)
   | None =>
     e = mk_ssn_not_exists_error initiator;
     throw e
-  | Some (Ssn status stake_amount rewards urlraw urlapi buffereddeposit) =>
+  | Some (Ssn status stake_amount rewards buffereddeposit urlinfo) =>
     pass = builtin eq buffereddeposit uint128_zero;
     match pass with
     | False =>
@@ -580,7 +586,7 @@ transition withdraw_stake_amount (amount : Uint128, initiator: ByStr20)
             throw e
           | False => (* pass minstake check for withdrawal *)
             (* Update the stake amount *)
-            ssn = Ssn status bal_left rewards urlraw urlapi buffereddeposit;
+            ssn = Ssn status bal_left rewards buffereddeposit urlinfo;
             ssnlist[initiator] := ssn;
             (* Update the total stake deposit with contract *)
             totalstakedeposit_l <- totalstakedeposit;
@@ -601,7 +607,7 @@ transition withdraw_stake_amount (amount : Uint128, initiator: ByStr20)
               (* entire stake withdrawed and also reward is withdrawed, so remove ssn *)
               delete ssnlist[initiator]
             | False =>
-              ssn = Ssn const_inactive uint128_zero rewards urlraw urlapi buffereddeposit;
+              ssn = Ssn const_inactive uint128_zero rewards buffereddeposit urlinfo;
               ssnlist[initiator] := ssn
             end;
             totalstakedeposit_l <- totalstakedeposit;

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -383,11 +383,11 @@ transition update_staking_parameter (min_stake : Uint128, max_stake : Uint128, c
   validate_not_paused;
   validate_proxy;
   validate_admin initiator;
-  less_than = builtin lt min_stake max_stake;
-  match less_than with
+  min_less_than_max = builtin lt min_stake max_stake;
+  match min_less_than_max with
   | True =>
-    less_than = builtin lt max_stake contract_max_stake;
-    match less_than with
+    max_less_than_contract_max = builtin lt max_stake contract_max_stake;
+    match max_less_than_contract_max with
     | True =>
       minstake := min_stake;
       maxstake := max_stake;
@@ -524,22 +524,22 @@ transition stake_deposit (initiator: ByStr20)
     maxstake_l <- maxstake;
     new_buff_amount = builtin add _amount buffereddeposit;
     new_stake_amount = builtin add new_buff_amount stake_amount;
-    pass = builtin lt new_stake_amount minstake_l;
-    match pass with
+    new_stake_less_than_min_stake = builtin lt new_stake_amount minstake_l;
+    match new_stake_less_than_min_stake with
     | True => (* stake deposit below minstake limit *)
       e = mk_stake_deposit_below_stake_limit_error initiator new_stake_amount minstake_l;
       throw e
     | False =>
-      pass = builtin lt maxstake_l new_stake_amount;
-      match pass with
+      max_stake_less_than_new_stake = builtin lt maxstake_l new_stake_amount;
+      match max_stake_less_than_new_stake with
       | True => (* stake deposit above maxstake limit *)
         e = mk_stake_deposit_above_stake_limit_error initiator new_stake_amount maxstake_l;
         throw e
       | False =>
         (* Add to total stake. Check that max stake has not been exceeded *)
         increase_totalstakedeposit _amount const_true initiator new_stake_amount;
-        pass = builtin eq stake_amount uint128_zero;
-        match pass with
+        stake_is_zero = builtin eq stake_amount uint128_zero;
+        match stake_is_zero with
         | True =>
           add_to_ssn_list initiator const_active _amount rewards uint128_zero urlinfo;
           e = mk_stake_deposit_event initiator _amount;
@@ -606,19 +606,19 @@ transition withdraw_stake_amount (amount : Uint128, initiator: ByStr20)
     e = mk_ssn_not_exists_error initiator;
     throw e
   | Some (Ssn status stake_amount rewards buffereddeposit urlinfo) =>
-    pass = builtin eq buffereddeposit uint128_zero;
-    match pass with
+    buffer_is_zero = builtin eq buffereddeposit uint128_zero;
+    match buffer_is_zero with
     | False =>
       e = mk_withdraw_stake_buffered_deposit_exist_error initiator buffereddeposit;
       throw e
     | True =>
-      pass = builtin lt amount stake_amount;
-      match pass with
+      amount_less_than_stake = builtin lt amount stake_amount;
+      match amount_less_than_stake with
       | True => (* Partial withdrawal. so check for min balance after withdrawal for min stake limit *)
           bal_left = builtin sub stake_amount amount;
           minstake_l <- minstake;
-          pass = builtin lt bal_left minstake_l;
-          match pass with
+          bal_left_less_than_min_stake = builtin lt bal_left minstake_l;
+          match bal_left_less_than_min_stake with
           | True =>
             e = mk_withdraw_below_stake_limit_error initiator minstake_l;
             throw e
@@ -627,14 +627,14 @@ transition withdraw_stake_amount (amount : Uint128, initiator: ByStr20)
             add_to_ssn_list initiator status bal_left rewards buffereddeposit urlinfo
           end
       | False => (* requested withdrawal equals balance or greater than balance *)
-          pass = builtin eq amount stake_amount;
-          match pass with
+          amount_is_stake = builtin eq amount stake_amount;
+          match amount_is_stake with
           | False => (* withdrawal above available balance *)
             e = mk_withdraw_above_stake_error initiator;
             throw e
           | True => (* pass withdrawal checks *)
-            pass = builtin eq rewards uint128_zero;
-            match pass with
+            reward_is_zero = builtin eq rewards uint128_zero;
+            match reward_is_zero with
             | True =>
               (* entire stake withdrawed and also reward is withdrawed, so remove ssn *)
               remove_from_ssn_list initiator

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -10,6 +10,7 @@ let one_msg =
     Cons {Message} m e
 
 let uint128_zero = Uint128 0
+let uint32_one = Uint32 1
 let const_true = True
 let const_false = False
 let uint128_10_power_7 = Uint128 10000000
@@ -182,6 +183,8 @@ contract SSNList(
 (* Mutable fields *)
 
 field ssnlist : Map ByStr20 Ssn = Emp ByStr20 Ssn
+(* Keep track of size explicitly, to avoid fetching entire map in order to check its size *)
+field ssnlist_size : Uint32 = Uint32 0
 field verifier : Option ByStr20 = None {ByStr20}
 field minstake : Uint128 = Uint128 0
 field maxstake : Uint128 = Uint128 0
@@ -192,6 +195,31 @@ field lastrewardblocknum : Uint128 = Uint128 0
 field paused : Bool = True
 
 (* Procedures *)
+(* Add/update key/value pair to ssn_list, and update size accordingly *)
+procedure add_to_ssn_list (key : ByStr20, value : Ssn)
+  already_exists <- exists ssnlist[key];
+  match already_exists with
+  | True =>
+  | False =>
+    siz <- ssnlist_size;
+    new_size = builtin add siz uint32_one;
+    ssnlist_size := new_size
+  end;
+  ssnlist[key] := value
+end
+
+(* Remove key/value pair from ssn_list, and update size accordingly *)
+procedure remove_from_ssn_list (key : ByStr20)
+  already_exists <- exists ssnlist[key];
+  match already_exists with
+  | False =>
+  | True =>
+    siz <- ssnlist_size;
+    new_size = builtin sub siz uint32_one;
+    ssnlist_size := new_size
+  end;
+  delete ssnlist[key]
+end  
 
 (* Can be called by the verifier only *)
 procedure validate_verifier (initiator : ByStr20)
@@ -264,7 +292,7 @@ procedure update_stake_reward (entry : SsnRewardShare)
       total_reward = calculate_new_reward stake_amount reward_percent rewards;
       new_stake_amount = builtin add stake_amount buffereddeposit;
       ssn = Ssn status new_stake_amount total_reward uint128_zero urlinfo;
-      ssnlist[ssnaddr] := ssn;
+      add_to_ssn_list ssnaddr ssn;
       e = mk_assign_stake_reward_event ssnaddr total_reward;
       event e
     end
@@ -366,8 +394,7 @@ transition add_ssn (ssnaddr : ByStr20, urlraw : String, urlapi : String, initiat
     e = mk_ssn_already_exists_error ssnaddr;
     throw e
   | False =>
-    ssns <- ssnlist;
-    current_ssn_number = builtin size ssns;
+    current_ssn_number <- ssnlist_size;
     less_than_max = builtin lt current_ssn_number max_ssn_node_number;
     match less_than_max with
     | True =>
@@ -377,7 +404,7 @@ transition add_ssn (ssnaddr : ByStr20, urlraw : String, urlapi : String, initiat
       rewards = Uint128 0;
       urlinfo = UrlInfo urlraw urlapi;
       s = Ssn status stake_amount rewards buffered_deposit urlinfo;
-      ssnlist[ssnaddr] := s;
+      add_to_ssn_list ssnaddr s;
       e = mk_ssn_added_event ssnaddr;
       event e      
     | False =>
@@ -406,8 +433,7 @@ transition add_ssn_after_upgrade (ssnaddr : ByStr20, stake_amount : Uint128, rew
     e = mk_ssn_already_exists_error ssnaddr;
     throw e
   | False =>
-    ssns <- ssnlist;
-    current_ssn_number = builtin size ssns;
+    current_ssn_number <- ssnlist_size;
     less_than_max = builtin lt current_ssn_number max_ssn_node_number;
     match less_than_max with
     | True =>
@@ -424,7 +450,7 @@ transition add_ssn_after_upgrade (ssnaddr : ByStr20, stake_amount : Uint128, rew
       end;
       urlinfo = UrlInfo urlraw urlapi;
       s = Ssn status stake_amount rewards buffered_deposit urlinfo;
-      ssnlist[ssnaddr] := s
+      add_to_ssn_list ssnaddr s
     | False =>
       e = mk_ssn_list_full_error initiator;
       throw e
@@ -445,7 +471,7 @@ transition remove_ssn (ssnaddr : ByStr20, initiator: ByStr20)
     funds_temp = builtin add stake_amount rewards;
     funds = builtin add funds_temp buffereddeposit;
     TransferFunds add_funds_tag funds ssnaddr;
-    delete ssnlist[ssnaddr];
+    remove_from_ssn_list ssnaddr;
     totalstakedeposit_l <- totalstakedeposit;
     totalstakedeposit_l = builtin sub totalstakedeposit_l stake_amount;
     totalstakedeposit := totalstakedeposit_l;
@@ -504,13 +530,13 @@ transition stake_deposit (initiator: ByStr20)
           match pass with
           | True =>
             ssn = Ssn const_active _amount rewards uint128_zero urlinfo;
-            ssnlist[initiator] := ssn;
+            add_to_ssn_list initiator ssn;
             e = mk_stake_deposit_event initiator _amount;
             event e
           | False =>
             (* Update new buffered deposit until next assign_stake_reward is finished *)
             ssn = Ssn const_active stake_amount rewards new_buff_amount urlinfo;
-            ssnlist[initiator] := ssn;
+            add_to_ssn_list initiator ssn;
             e = mk_stake_buffered_deposit_event initiator _amount;
             event e
           end;
@@ -550,11 +576,11 @@ transition withdraw_stake_rewards (initiator : ByStr20)
     match pass with
     | True =>
       (* entire stake withdrawn and also reward is withdrawn, so remove ssn *)
-      delete ssnlist[initiator]
+      remove_from_ssn_list initiator
     | False =>
       (* Update state to have 0 rewards. *)
       ssn = Ssn status stake_amount uint128_zero buffereddeposit urlinfo;
-      ssnlist[initiator] := ssn
+      add_to_ssn_list initiator ssn
     end;
     TransferFunds add_funds_tag rewards initiator;
     e = mk_withdraw_stake_rewards_event initiator rewards;
@@ -593,7 +619,7 @@ transition withdraw_stake_amount (amount : Uint128, initiator: ByStr20)
           | False => (* pass minstake check for withdrawal *)
             (* Update the stake amount *)
             ssn = Ssn status bal_left rewards buffereddeposit urlinfo;
-            ssnlist[initiator] := ssn;
+            add_to_ssn_list initiator ssn;
             (* Update the total stake deposit with contract *)
             totalstakedeposit_l <- totalstakedeposit;
             tmp = builtin sub totalstakedeposit_l amount;
@@ -611,10 +637,10 @@ transition withdraw_stake_amount (amount : Uint128, initiator: ByStr20)
             match pass with
             | True =>
               (* entire stake withdrawed and also reward is withdrawed, so remove ssn *)
-              delete ssnlist[initiator]
+              remove_from_ssn_list initiator
             | False =>
               ssn = Ssn const_inactive uint128_zero rewards buffereddeposit urlinfo;
-              ssnlist[initiator] := ssn
+              add_to_ssn_list initiator ssn
             end;
             totalstakedeposit_l <- totalstakedeposit;
             tmp = builtin sub totalstakedeposit_l amount;

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -225,7 +225,7 @@ procedure validate_proxy ()
 end
 
 (* Can be called by the proxy only *)
-procedure is_paused ()
+procedure validate_not_paused ()
   paused_l <- paused;
   match paused_l with
   | False =>
@@ -320,7 +320,7 @@ end
 (* @param contract_max_stake: New contract maxstake value *)
 (* @param initiator: The original caller who called the proxy *)
 transition update_staking_parameter (min_stake : Uint128, max_stake : Uint128, contract_max_stake : Uint128, initiator : ByStr20)
-  is_paused;
+  validate_not_paused;
   validate_proxy;
   validate_admin initiator;
   less_than = builtin lt min_stake max_stake;
@@ -351,7 +351,7 @@ end
 (* @param urlapi: string representing url exposed by ssn serving public api request *)
 (* @param initiator: The original caller who called the proxy *)
 transition add_ssn (ssnaddr : ByStr20, urlraw : String, urlapi : String, initiator : ByStr20)
-  is_paused;
+  validate_not_paused;
   validate_proxy;
   validate_admin initiator;
   already_exists <- exists ssnlist[ssnaddr];
@@ -391,7 +391,7 @@ end
 (* @param buffered_deposit: Any buffered stake deposit *)
 (* @param initiator: The original caller who called the proxy *)
 transition add_ssn_after_upgrade (ssnaddr : ByStr20, stake_amount : Uint128, rewards : Uint128, urlraw : String, urlapi : String, buffered_deposit : Uint128, initiator : ByStr20)
-  is_paused;
+  validate_not_paused;
   validate_proxy;
   validate_admin initiator;
   already_exists <- exists ssnlist[ssnaddr];
@@ -430,7 +430,7 @@ end
 (* @param ssnaddr: Address of the ssn to be removed *)
 (* @param initiator: The original caller who called the proxy *)
 transition remove_ssn (ssnaddr : ByStr20, initiator: ByStr20)
-  is_paused;
+  validate_not_paused;
   validate_proxy;
   validate_admin initiator;
   ssn_optional <- ssnlist[ssnaddr];
@@ -456,7 +456,7 @@ end
 (* @dev: Stake amount of existing ssn in ssnlist will be updated with new amount only if existing stake amount is 0. Balance of contract account will increase. Balance of initiator will decrease.      *)
 (* @param initiator: The original caller who called the proxy *)
 transition stake_deposit (initiator: ByStr20)
-  is_paused;
+  validate_not_paused;
   validate_proxy;
   (* Accept the deposit from SSN and add to contract balance. *)
   (* Transfer back to initiator if any of the validation failed *)
@@ -521,7 +521,7 @@ end
 (* @param reward_blocknum: tx block num when ssns were verified *)
 (* @param initiator: The original caller who called the proxy *)
 transition assign_stake_reward (ssnreward_list : List SsnRewardShare, reward_blocknum : Uint128, initiator: ByStr20)
-  is_paused;
+  validate_not_paused;
   validate_proxy;
   validate_verifier initiator;
   forall ssnreward_list update_stake_reward;
@@ -531,7 +531,7 @@ end
 (* @dev: Withdraw stake reward. Used by ssn only. *)
 (* @param initiator: The original caller who called the proxy *)
 transition withdraw_stake_rewards (initiator : ByStr20)
-  is_paused;
+  validate_not_paused;
   validate_proxy;
   curval <- ssnlist[initiator];
   match curval with
@@ -560,7 +560,7 @@ end
 (* @param amount: token amount to be withdrawn *)
 (* @param initiator: The original caller who called the proxy *)
 transition withdraw_stake_amount (amount : Uint128, initiator: ByStr20)
-  is_paused;
+  validate_not_paused;
   validate_proxy;
   curval <- ssnlist[initiator];
   match curval with
@@ -623,7 +623,7 @@ end
 (* @dev: Move token amount from initiator to recipient i.e. contract address. *)
 (* @param initiator: The original caller who called the proxy *)
 transition AddFunds (initiator : ByStr20)
-  is_paused;
+  validate_not_paused;
   validate_proxy;
   accept;
   e = mk_add_funds_event initiator;

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -10,8 +10,8 @@ let one_msg =
     Cons {Message} m e
 
 let uint128_zero = Uint128 0
-let bool_active = True
-let bool_inactive = False
+let const_true = True
+let const_false = False
 let uint128_10_power_7 = Uint128 10000000
 let empty_tag = ""
 let add_funds_tag = "AddFunds"
@@ -129,8 +129,22 @@ let mk_withdraw_stake_rewards_event =
       { _exception : "SSN withdrawal not allowed when some deposit is bufferred"; ssn_address : ssn; buffered_stake_amount : buffdeposit }
 
 (* Ssn - active_status , stake_amount, rewards, urlraw, urlapi, buffereddeposit *)
+type ActiveStatus =
+| Active
+| Inactive
+
+let const_active = Active
+let const_inactive = Inactive
+
+let active_status_from_neg_bool =
+  fun (cur_status : Bool) =>
+    match cur_status with
+    | True => const_inactive
+    | False => const_active
+    end
+
 type Ssn =
-| Ssn of Bool Uint128 Uint128 String String Uint128
+| Ssn of ActiveStatus Uint128 Uint128 String String Uint128
 
 (* address reward_percentage *)
 type SsnRewardShare =
@@ -232,14 +246,14 @@ procedure update_stake_reward (entry : SsnRewardShare)
     | None =>
       e = mk_ssn_not_exists_error ssnaddr;
       throw e
-    | Some (Ssn active_status stake_amount rewards urlraw urlapi buffereddeposit) =>
+    | Some (Ssn status stake_amount rewards urlraw urlapi buffereddeposit) =>
       hundred = Uint128 100;
       new_reward = builtin mul stake_amount reward_percent;
       new_reward = builtin div new_reward hundred;
       new_reward = builtin div new_reward uint128_10_power_7;
       total_reward = builtin add new_reward rewards;
       new_stake_amount = builtin add stake_amount buffereddeposit;
-      ssn = Ssn active_status new_stake_amount total_reward urlraw urlapi uint128_zero;
+      ssn = Ssn status new_stake_amount total_reward urlraw urlapi uint128_zero;
       ssnlist[ssnaddr] := ssn;
       e = mk_assign_stake_reward_event ssnaddr total_reward;
       event e
@@ -254,7 +268,7 @@ end
 transition pause(initiator: ByStr20)
     validate_proxy;
     validate_admin initiator;
-    paused := bool_active
+    paused := const_true
 end
 
 (* @dev: unpause/unfreeze the contract. Used by admin only. *)
@@ -262,7 +276,7 @@ end
 transition unpause(initiator: ByStr20)
     validate_proxy;
     validate_admin initiator;
-    paused := bool_inactive
+    paused := const_false
 end
 
 (* @dev: Set the admin of contract. Used by admin only. *)
@@ -348,7 +362,7 @@ transition add_ssn (ssnaddr : ByStr20, urlraw : String, urlapi : String, initiat
     match less_than_max with
     | True =>
       stake_amount = Uint128 0;
-      status = False;
+      status = const_inactive;
       buffered_deposit = Uint128 0;
       rewards = Uint128 0;
       s = Ssn status stake_amount rewards urlraw urlapi buffered_deposit;
@@ -388,7 +402,7 @@ transition add_ssn_after_upgrade (ssnaddr : ByStr20, stake_amount : Uint128, rew
     | True =>
       pass = builtin eq stake_amount uint128_zero;
       (* set status as inactive if stake_amount is 0 *)
-      status = negb pass;
+      status = active_status_from_neg_bool pass;
       match pass with
       | True =>
       | False =>
@@ -415,7 +429,7 @@ transition remove_ssn (ssnaddr : ByStr20, initiator: ByStr20)
   validate_admin initiator;
   ssn_optional <- ssnlist[ssnaddr];
   match ssn_optional with
-  | Some (Ssn active_status stake_amount rewards urlraw urlapi buffereddeposit) =>
+  | Some (Ssn _ stake_amount rewards urlraw urlapi buffereddeposit) =>
     funds_temp = builtin add stake_amount rewards;
     funds = builtin add funds_temp buffereddeposit;
     TransferFunds add_funds_tag funds ssnaddr;
@@ -446,7 +460,7 @@ transition stake_deposit (initiator: ByStr20)
   | None =>
     e = mk_ssn_not_exists_error initiator;
     throw e
-  | Some (Ssn active_status stake_amount rewards urlraw urlapi buffereddeposit) =>
+  | Some (Ssn _ stake_amount rewards urlraw urlapi buffereddeposit) =>
     (* check if first non-zero deposit *)
     minstake_l <- minstake;
     maxstake_l <- maxstake;
@@ -477,13 +491,13 @@ transition stake_deposit (initiator: ByStr20)
           pass = builtin eq stake_amount uint128_zero;
           match pass with
           | True =>
-            ssn = Ssn bool_active _amount rewards urlraw urlapi uint128_zero;
+            ssn = Ssn const_active _amount rewards urlraw urlapi uint128_zero;
             ssnlist[initiator] := ssn;
             e = mk_stake_deposit_event initiator _amount;
             event e
           | False =>
             (* Update new buffered deposit until next assign_stake_reward is finished *)
-            ssn = Ssn bool_active stake_amount rewards urlraw urlapi new_buff_amount;
+            ssn = Ssn const_active stake_amount rewards urlraw urlapi new_buff_amount;
             ssnlist[initiator] := ssn;
             e = mk_stake_buffered_deposit_event initiator _amount;
             event e
@@ -518,7 +532,7 @@ transition withdraw_stake_rewards (initiator : ByStr20)
   | None =>
     e = mk_ssn_not_exists_error initiator;
     throw e
-  | Some (Ssn active_status stake_amount rewards urlraw urlapi buffereddeposit) =>
+  | Some (Ssn status stake_amount rewards urlraw urlapi buffereddeposit) =>
     (* check if basic stake deposit is already withdrawn by ssn. If so, remove the ssn from list as well *)
     pass = builtin eq stake_amount uint128_zero;
     match pass with
@@ -527,7 +541,7 @@ transition withdraw_stake_rewards (initiator : ByStr20)
       delete ssnlist[initiator]
     | False =>
       (* Update state to have 0 rewards. *)
-      ssn = Ssn active_status stake_amount uint128_zero urlraw urlapi buffereddeposit;
+      ssn = Ssn status stake_amount uint128_zero urlraw urlapi buffereddeposit;
       ssnlist[initiator] := ssn
     end;
     TransferFunds add_funds_tag rewards initiator;
@@ -547,7 +561,7 @@ transition withdraw_stake_amount (amount : Uint128, initiator: ByStr20)
   | None =>
     e = mk_ssn_not_exists_error initiator;
     throw e
-  | Some (Ssn active_status stake_amount rewards urlraw urlapi buffereddeposit) =>
+  | Some (Ssn status stake_amount rewards urlraw urlapi buffereddeposit) =>
     pass = builtin eq buffereddeposit uint128_zero;
     match pass with
     | False =>
@@ -566,7 +580,7 @@ transition withdraw_stake_amount (amount : Uint128, initiator: ByStr20)
             throw e
           | False => (* pass minstake check for withdrawal *)
             (* Update the stake amount *)
-            ssn = Ssn active_status bal_left rewards urlraw urlapi buffereddeposit;
+            ssn = Ssn status bal_left rewards urlraw urlapi buffereddeposit;
             ssnlist[initiator] := ssn;
             (* Update the total stake deposit with contract *)
             totalstakedeposit_l <- totalstakedeposit;
@@ -587,7 +601,7 @@ transition withdraw_stake_amount (amount : Uint128, initiator: ByStr20)
               (* entire stake withdrawed and also reward is withdrawed, so remove ssn *)
               delete ssnlist[initiator]
             | False =>
-              ssn = Ssn bool_inactive uint128_zero rewards urlraw urlapi buffereddeposit;
+              ssn = Ssn const_inactive uint128_zero rewards urlraw urlapi buffereddeposit;
               ssnlist[initiator] := ssn
             end;
             totalstakedeposit_l <- totalstakedeposit;

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -222,6 +222,32 @@ procedure remove_from_ssn_list (key : ByStr20)
   delete ssnlist[key]
 end  
 
+(* Increase total stake deposit *)
+procedure increase_totalstakedeposit (amount : Uint128, check_max : Bool, initiator : ByStr20, new_stake_amount : Uint128)
+  deposit <- totalstakedeposit;
+  new_deposit = builtin add deposit amount;
+  match check_max with
+  | False =>
+  | True =>
+    max_stake <- contractmaxstake;
+    pass = builtin lt max_stake new_deposit;
+    match pass with
+    | True =>
+      e = mk_total_stake_deposit_above_contract_stake_limit_error initiator new_stake_amount max_stake;
+      throw e
+    | False =>
+    end
+  end;
+  totalstakedeposit := new_deposit
+end
+
+(* Decrease total stake deposit *)
+procedure decrease_totalstakedeposit (amount : Uint128)
+  deposit <- totalstakedeposit;
+  new_deposit = builtin sub deposit amount;
+  totalstakedeposit := new_deposit
+end
+
 (* Can be called by the verifier only *)
 procedure validate_verifier (initiator : ByStr20)
   verifier_l <- verifier;
@@ -442,10 +468,8 @@ transition add_ssn_after_upgrade (ssnaddr : ByStr20, stake_amount : Uint128, rew
       match pass with
       | True =>
       | False =>
-        (* Update the total stake deposit *)
-        totalstakedeposit_l <- totalstakedeposit;
-        totalstakedeposit_l = builtin add totalstakedeposit_l stake_amount;
-        totalstakedeposit := totalstakedeposit_l
+        (* Update the total stake deposit. Do not check that max has been exceeded *)
+        increase_totalstakedeposit stake_amount const_false initiator stake_amount
       end;
       urlinfo = UrlInfo urlraw urlapi;
       add_to_ssn_list ssnaddr status stake_amount rewards buffered_deposit urlinfo
@@ -470,9 +494,7 @@ transition remove_ssn (ssnaddr : ByStr20, initiator: ByStr20)
     funds = builtin add funds_temp buffereddeposit;
     TransferFunds add_funds_tag funds ssnaddr;
     remove_from_ssn_list ssnaddr;
-    totalstakedeposit_l <- totalstakedeposit;
-    totalstakedeposit_l = builtin sub totalstakedeposit_l stake_amount;
-    totalstakedeposit := totalstakedeposit_l;
+    decrease_totalstakedeposit stake_amount;
     e = mk_ssn_removed_event ssnaddr;
     event e
   | None =>
@@ -514,30 +536,19 @@ transition stake_deposit (initiator: ByStr20)
         e = mk_stake_deposit_above_stake_limit_error initiator new_stake_amount maxstake_l;
         throw e
       | False =>
-        totalstakedeposit_l <- totalstakedeposit;
-        newStakeDeposit = builtin add totalstakedeposit_l _amount;
-        contractmaxstake_l <- contractmaxstake;
-        pass = builtin lt contractmaxstake_l newStakeDeposit;
+        (* Add to total stake. Check that max stake has not been exceeded *)
+        increase_totalstakedeposit _amount const_true initiator new_stake_amount;
+        pass = builtin eq stake_amount uint128_zero;
         match pass with
-        | True => (* total stake deposit for contract goes above contractmaxstake limit *)
-          e = mk_total_stake_deposit_above_contract_stake_limit_error initiator new_stake_amount contractmaxstake_l;
-          throw e
+        | True =>
+          add_to_ssn_list initiator const_active _amount rewards uint128_zero urlinfo;
+          e = mk_stake_deposit_event initiator _amount;
+          event e
         | False =>
-          (* Check if its first time deposit *)
-          pass = builtin eq stake_amount uint128_zero;
-          match pass with
-          | True =>
-            add_to_ssn_list initiator const_active _amount rewards uint128_zero urlinfo;
-            e = mk_stake_deposit_event initiator _amount;
-            event e
-          | False =>
-            (* Update new buffered deposit until next assign_stake_reward is finished *)
-            add_to_ssn_list initiator const_active stake_amount rewards new_buff_amount urlinfo;
-            e = mk_stake_buffered_deposit_event initiator _amount;
-            event e
-          end;
-          (* Update the new total stake deposit of contract *)
-          totalstakedeposit := newStakeDeposit
+          (* Update new buffered deposit until next assign_stake_reward is finished *)
+          add_to_ssn_list initiator const_active stake_amount rewards new_buff_amount urlinfo;
+          e = mk_stake_buffered_deposit_event initiator _amount;
+          event e
         end
       end
     end
@@ -613,12 +624,7 @@ transition withdraw_stake_amount (amount : Uint128, initiator: ByStr20)
             throw e
           | False => (* pass minstake check for withdrawal *)
             (* Update the stake amount *)
-            add_to_ssn_list initiator status bal_left rewards buffereddeposit urlinfo;
-            (* Update the total stake deposit with contract *)
-            totalstakedeposit_l <- totalstakedeposit;
-            tmp = builtin sub totalstakedeposit_l amount;
-            totalstakedeposit := tmp;
-            TransferFunds add_funds_tag amount initiator
+            add_to_ssn_list initiator status bal_left rewards buffereddeposit urlinfo
           end
       | False => (* requested withdrawal equals balance or greater than balance *)
           pass = builtin eq amount stake_amount;
@@ -634,13 +640,12 @@ transition withdraw_stake_amount (amount : Uint128, initiator: ByStr20)
               remove_from_ssn_list initiator
             | False =>
               add_to_ssn_list initiator const_inactive uint128_zero rewards buffereddeposit urlinfo
-            end;
-            totalstakedeposit_l <- totalstakedeposit;
-            tmp = builtin sub totalstakedeposit_l amount;
-            totalstakedeposit := tmp;
-            TransferFunds add_funds_tag amount initiator
+            end
           end
-        end
+        end;
+      (* Update the total stake deposit with contract *)
+      decrease_totalstakedeposit amount;
+      TransferFunds add_funds_tag amount initiator
     end
   end
 end


### PR DESCRIPTION
I have reorganised the code somewhat. Feel free to cherry-pick the individual commits, and/or let yourselves be inspired to do something even better. :-)

Other observations:

* In general: I would like to change the contract interface (the parameters to the transitions), but I don't know to what extent they are fixed. I have added some comments below as to what I think ought to be changed.

* urlraw+urlapi -> UrlInfo:
  - The urls do not seem to be used by the contract at all. Presumably there is some reason they are stored? This is the reason I have moved the UrlInfo value to the last value of Ssn - if there is no logic attached to it, then just put it last.
  - Consider changing the url parameters of add_ssn and add_ssn_after_upgrade from `urlraw : String, urlapi : String` to `urlinfo : UrlInfo`. The message json would need to construct a UrlInfo object, but that's no more difficult than constructing a list.

* field ssnlist: I get a bit jittery whenever I see a map with the name `...list`. It's not a list - it's a map. Can the name be changed to `ssns`?

* Am I right in thinking that once a verifier has been set, then there will always be a verifier? If so, would it then be possible to set a verifier when the contract is deployed, e.g., like this:
```
field verifier : ByStr20 = init_admin
```
That would simplify some of the logic when the verifier is checked.

* decrease_totalstakedeposit: builtin sub deposit amount can in principle result in an underflow, but I suppose that's not an issue due to some contract invariant?
