### PR TITLE
fix(ssn): use proxyaddr field, not initial contract parameter

### DIFF
--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -374,7 +374,8 @@ end
 
 (* Check if the caller is the proxy *)
 procedure IsProxy()
-  is_proxy = builtin eq _sender proxy_address;
+  proxyaddr_tmp <- proxyaddr;
+  is_proxy = builtin eq _sender proxyaddr_tmp;
   match is_proxy with
   | True  =>
   | False =>


### PR DESCRIPTION
The `IsProxy` procedure uses the immutable contract parameter `proxy_address` instead.