### PR TITLE
fix: remove wrong code

### DIFF
--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -570,7 +570,6 @@ procedure AdjustDeleg(ssnaddr: ByStr20, deleg: ByStr20, total_amount: Uint128, w
       ssn_deleg_amt[ssnaddr][deleg] := rest_deleg;
       direct_deposit_deleg[deleg][ssnaddr][lrc] := rest_deleg;
       last_withdraw_cycle_deleg[deleg][ssnaddr] := lrc;
-      last_buf_deposit_cycle_deleg[deleg][ssnaddr] := lrc
     end
   | False =>
     e = DelegHasNoSufficientAmt;


### PR DESCRIPTION
Bug: we should not fill `field last_buf_deposit_cycle_deleg` when doing `AdjustDeleg`, because here all we deal with is direct deposit.