### PR TITLE
fix: clarify reward cycle

### DIFF
--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -238,11 +238,11 @@ field last_withdraw_cycle_deleg: Map ByStr20 (Map ByStr20 Uint128) = Emp ByStr20
 field last_buf_deposit_cycle_deleg: Map ByStr20 (Map ByStr20 Uint128) = Emp ByStr20 (Map ByStr20 Uint128)
 (* AddressOfSSN -> (RewardCycleNumber -> Pair (TotalStakeDuringTheCycleForSSN, TotalRewardEarnedDuringTheCycle) *)
 field stake_ssn_per_cycle: Map ByStr20 (Map Uint128 SSNCycleInfo) = Emp ByStr20 (Map Uint128 SSNCycleInfo)
+(* AddressOfDeleg -> AddressOfSSN -> EffectCycleNum -> Deposit *)
+field deleg_stake_per_cycle: Map ByStr20 (Map ByStr20 (Map Uint128 Uint128)) = Emp ByStr20 (Map ByStr20 (Map Uint128 Uint128))
 field withdrawal_pending: Map ByStr20 (Map BNum Uint128) = Emp ByStr20 (Map BNum Uint128)
 field bnum_req: Uint128 = Uint128 24000
 (* Temporary storage map *)
-(* Used during CalcStakeDelegPerCycle *)
-field stake_deleg_per_cycle: Map Uint128 Uint128 = Emp Uint128 Uint128
 (* Used during CalcRewardsDelegPerCycle *)
 field rewards_amt_deleg: Map ByStr20 (Map ByStr20 Uint128) = Emp ByStr20 (Map ByStr20 Uint128)
 field avaiable_withdrawal: Uint128 = uint128_zero
@@ -618,20 +618,21 @@ end
 procedure CalcStakeDelegPerCycle(tmp_arg: TmpArg)
   match tmp_arg with
   | TmpArg deleg ssn_operator reward_cycle =>
-    (* Combine buffered and direct - this replaces combine_buffered_and_direct *)
     last_reward_cycle = builtin sub reward_cycle uint128_one;
     last2_reward_cycle = sub_one_to_zero last_reward_cycle;
     cur_opt <- direct_deposit_deleg[deleg][ssn_operator][last_reward_cycle];
     buf_opt <- buff_deposit_deleg[deleg][ssn_operator][last2_reward_cycle];
     comb_opt = option_add cur_opt buf_opt;
-    (* Calculate final staking per cycle for delegs - this replaces calculate_all_stake_pr_cycle *)
-    result_map_opt <- stake_deleg_per_cycle[last_reward_cycle];
-    stake_opt = option_add comb_opt result_map_opt;
-    match stake_opt with
+
+    last_amt_o <- deleg_stake_per_cycle[deleg][ssn_operator][last_reward_cycle];
+    last_amt = option_uint128_value last_amt_o;
+    
+    match comb_opt with
     | Some stake =>
-      stake_deleg_per_cycle[reward_cycle] := stake
+      total_stake = builtin add last_amt stake;
+      deleg_stake_per_cycle[deleg][ssn_operator][reward_cycle] := total_stake
     | None =>
-      stake_deleg_per_cycle[reward_cycle] := uint128_zero
+      deleg_stake_per_cycle[deleg][ssn_operator][reward_cycle] := last_amt
     end
   end
 end
@@ -655,7 +656,7 @@ procedure CalcRewardsDelegPerCycle(tmp_arg: TmpArg)
   match tmp_arg with
   | TmpArg deleg ssn_operator reward_cycle =>
     (* Calculate staking rewards per cycle for deleg *)
-    staking_per_cycle_for_deleg_opt <- stake_deleg_per_cycle[reward_cycle];
+    staking_per_cycle_for_deleg_opt <- deleg_stake_per_cycle[deleg][ssn_operator][reward_cycle];
     staking_and_rewards_per_cycle_for_ssn_opt <- stake_ssn_per_cycle[ssn_operator][reward_cycle];
     match staking_per_cycle_for_deleg_opt with
     | Some staking_of_deleg =>
@@ -680,17 +681,16 @@ procedure WithdrawalStakeRewards(deleg: ByStr20, ssn_operator: ByStr20)
   rcl_reverse = list_reverse_uint128 rcl;
   (* those are the cycles that we want to compute for computing rewards *)
   list_need_compute_rewards = list_filter_between last_withdraw_cycle lrc rcl;
+  
+  list_reverse_uint128 = @list_reverse Uint128;
+  list_need_compute_rewards_reverse = list_reverse_uint128 list_need_compute_rewards;
   (* Combine deleg and ssn_operator with list_need_compute_rewards *)
   mapper = @list_map Uint128 TmpArg;
   f = fun (cycle: Uint128) => TmpArg deleg ssn_operator cycle;
   combined_args_list = mapper f list_need_compute_rewards;
 
-
-  (* calculate stake_deleg_per_cycle *)
-  emp_map = Emp Uint128 Uint128;
-  stake_deleg_per_cycle := emp_map;
-  rcl_reverse_t = mapper f rcl_reverse;
-  forall rcl_reverse_t CalcStakeDelegPerCycle;
+  list_need_compute_rewards_t = mapper f list_need_compute_rewards_reverse;
+  forall list_need_compute_rewards_t CalcStakeDelegPerCycle;
 
   (* Calculate rewards *)
   rewards_amt_deleg[ssn_operator][deleg] := uint128_zero;
@@ -710,9 +710,7 @@ procedure WithdrawalStakeRewards(deleg: ByStr20, ssn_operator: ByStr20)
     ssnlist[ssn_operator] := ssn
   | None => (* won't reach *)
   end;
-  sdpc <- stake_deleg_per_cycle;
-  sdpc_list = builtin to_list sdpc;
-  e = { _eventname: "WithdrawalStakeRewards"; reward_list_need: list_need_compute_rewards; combined_args_list: combined_args_list; stake_deleg_per_cycle: sdpc_list };
+  e = { _eventname: "WithdrawalStakeRewards"; reward_list_need: list_need_compute_rewards; combined_args_list: combined_args_list };
   event e;
   last_withdraw_cycle_deleg[deleg][ssn_operator] := lrc
 end

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -654,10 +654,9 @@ end
 procedure CalcRewardsDelegPerCycle(tmp_arg: TmpArg)
   match tmp_arg with
   | TmpArg deleg ssn_operator reward_cycle =>
-    (* Calculate staking rewards per cycle for deleg - this replaces calculate_rewards_per_cycle_for_deleg *)
+    (* Calculate staking rewards per cycle for deleg *)
     staking_per_cycle_for_deleg_opt <- stake_deleg_per_cycle[reward_cycle];
-    lrc = builtin sub reward_cycle uint128_one;
-    staking_and_rewards_per_cycle_for_ssn_opt <- stake_ssn_per_cycle[ssn_operator][lrc];
+    staking_and_rewards_per_cycle_for_ssn_opt <- stake_ssn_per_cycle[ssn_operator][reward_cycle];
     match staking_per_cycle_for_deleg_opt with
     | Some staking_of_deleg =>
       match staking_and_rewards_per_cycle_for_ssn_opt with
@@ -1074,12 +1073,12 @@ transition AssignStakeReward(ssnreward_list: List SsnRewardShare, verifier_rewar
   IsProxy;
   CallerIsVerifier initiator;
   lrc <- lastrewardcycle;
-  forall ssnreward_list UpdateStakeReward;
   newLastRewardCycleNum = builtin add uint128_one lrc;
   lastrewardcycle := newLastRewardCycleNum;
   rcl <- reward_cycle_list;
   rcl_new = Cons {Uint128} newLastRewardCycleNum rcl;
   reward_cycle_list := rcl_new;
+  forall ssnreward_list UpdateStakeReward;
   verifier_o <- verifier_receiving_addr;
   match verifier_o with
   | Some v => 

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -734,7 +734,6 @@ procedure Delegate(ssnaddr: ByStr20, initiator: ByStr20, amount: Uint128)
     | True  =>
       last_buf_deposit_cycle_deleg[initiator][ssnaddr] := lrc;
       new_buff_amt  = builtin add amount buffdeposit;
-      new_stake_amt = builtin add new_buff_amt stake_amt;
       (* The SSN is active so add the delegated stake to the buffer *)
       ssn = Ssn bool_active stake_amt rewards name urlraw urlapi new_buff_amt comm comm_rewards rec_addr;
       ssnlist[ssnaddr] := ssn;

--- a/tests/ssnlist.scilla
+++ b/tests/ssnlist.scilla
@@ -96,7 +96,6 @@ type Error =
 | InvalidTotalAmt
 | InvalidRecvAddr
 | VerifierNotSet
-| NotTimeYet
 | VerifierRecvAddrNotSet
 let make_error =
 fun (result: Error) =>
@@ -417,7 +416,7 @@ TruncateDeleg deleg ssnaddr;
 deposit_amt_deleg[deleg][ssnaddr] := rest_deleg;
 ssn_deleg_amt[ssnaddr][deleg] := rest_deleg;
 direct_deposit_deleg[deleg][ssnaddr][lrc] := rest_deleg;
-last_withdraw_cycle_deleg[deleg][ssnaddr] := lrc;
+last_withdraw_cycle_deleg[deleg][ssnaddr] := lrc
 end
 | False =>
 e = DelegHasNoSufficientAmt;
@@ -495,8 +494,7 @@ procedure CalcRewardsDelegPerCycle(tmp_arg: TmpArg)
 match tmp_arg with
 | TmpArg deleg ssn_operator reward_cycle =>
 staking_per_cycle_for_deleg_opt <- stake_deleg_per_cycle[reward_cycle];
-lrc = builtin sub reward_cycle uint128_one;
-staking_and_rewards_per_cycle_for_ssn_opt <- stake_ssn_per_cycle[ssn_operator][lrc];
+staking_and_rewards_per_cycle_for_ssn_opt <- stake_ssn_per_cycle[ssn_operator][reward_cycle];
 match staking_per_cycle_for_deleg_opt with
 | Some staking_of_deleg =>
 match staking_and_rewards_per_cycle_for_ssn_opt with
@@ -805,12 +803,12 @@ IsPaused;
 IsProxy;
 CallerIsVerifier initiator;
 lrc <- lastrewardcycle;
-forall ssnreward_list UpdateStakeReward;
 newLastRewardCycleNum = builtin add uint128_one lrc;
 lastrewardcycle := newLastRewardCycleNum;
 rcl <- reward_cycle_list;
 rcl_new = Cons {Uint128} newLastRewardCycleNum rcl;
 reward_cycle_list := rcl_new;
+forall ssnreward_list UpdateStakeReward;
 verifier_o <- verifier_receiving_addr;
 match verifier_o with
 | Some v =>

--- a/tests/ssnlist.scilla
+++ b/tests/ssnlist.scilla
@@ -137,9 +137,9 @@ field direct_deposit_deleg: Map ByStr20 (Map ByStr20 (Map Uint128 Uint128)) = Em
 field last_withdraw_cycle_deleg: Map ByStr20 (Map ByStr20 Uint128) = Emp ByStr20 (Map ByStr20 Uint128)
 field last_buf_deposit_cycle_deleg: Map ByStr20 (Map ByStr20 Uint128) = Emp ByStr20 (Map ByStr20 Uint128)
 field stake_ssn_per_cycle: Map ByStr20 (Map Uint128 SSNCycleInfo) = Emp ByStr20 (Map Uint128 SSNCycleInfo)
+field deleg_stake_per_cycle: Map ByStr20 (Map ByStr20 (Map Uint128 Uint128)) = Emp ByStr20 (Map ByStr20 (Map Uint128 Uint128))
 field withdrawal_pending: Map ByStr20 (Map BNum Uint128) = Emp ByStr20 (Map BNum Uint128)
 field bnum_req: Uint128 = Uint128 24000
-field stake_deleg_per_cycle: Map Uint128 Uint128 = Emp Uint128 Uint128
 field rewards_amt_deleg: Map ByStr20 (Map ByStr20 Uint128) = Emp ByStr20 (Map ByStr20 Uint128)
 field avaiable_withdrawal: Uint128 = uint128_zero
 field current_deleg: Option ByStr20 = None {ByStr20}
@@ -467,13 +467,14 @@ last2_reward_cycle = sub_one_to_zero last_reward_cycle;
 cur_opt <- direct_deposit_deleg[deleg][ssn_operator][last_reward_cycle];
 buf_opt <- buff_deposit_deleg[deleg][ssn_operator][last2_reward_cycle];
 comb_opt = option_add cur_opt buf_opt;
-result_map_opt <- stake_deleg_per_cycle[last_reward_cycle];
-stake_opt = option_add comb_opt result_map_opt;
-match stake_opt with
+last_amt_o <- deleg_stake_per_cycle[deleg][ssn_operator][last_reward_cycle];
+last_amt = option_uint128_value last_amt_o;
+match comb_opt with
 | Some stake =>
-stake_deleg_per_cycle[reward_cycle] := stake
+total_stake = builtin add last_amt stake;
+deleg_stake_per_cycle[deleg][ssn_operator][reward_cycle] := total_stake
 | None =>
-stake_deleg_per_cycle[reward_cycle] := uint128_zero
+deleg_stake_per_cycle[deleg][ssn_operator][reward_cycle] := last_amt
 end
 end
 end
@@ -493,7 +494,7 @@ end
 procedure CalcRewardsDelegPerCycle(tmp_arg: TmpArg)
 match tmp_arg with
 | TmpArg deleg ssn_operator reward_cycle =>
-staking_per_cycle_for_deleg_opt <- stake_deleg_per_cycle[reward_cycle];
+staking_per_cycle_for_deleg_opt <- deleg_stake_per_cycle[deleg][ssn_operator][reward_cycle];
 staking_and_rewards_per_cycle_for_ssn_opt <- stake_ssn_per_cycle[ssn_operator][reward_cycle];
 match staking_per_cycle_for_deleg_opt with
 | Some staking_of_deleg =>
@@ -516,13 +517,13 @@ rcl <- reward_cycle_list;
 list_reverse_uint128 = @list_reverse Uint128;
 rcl_reverse = list_reverse_uint128 rcl;
 list_need_compute_rewards = list_filter_between last_withdraw_cycle lrc rcl;
+list_reverse_uint128 = @list_reverse Uint128;
+list_need_compute_rewards_reverse = list_reverse_uint128 list_need_compute_rewards;
 mapper = @list_map Uint128 TmpArg;
 f = fun (cycle: Uint128) => TmpArg deleg ssn_operator cycle;
 combined_args_list = mapper f list_need_compute_rewards;
-emp_map = Emp Uint128 Uint128;
-stake_deleg_per_cycle := emp_map;
-rcl_reverse_t = mapper f rcl_reverse;
-forall rcl_reverse_t CalcStakeDelegPerCycle;
+list_need_compute_rewards_t = mapper f list_need_compute_rewards_reverse;
+forall list_need_compute_rewards_t CalcStakeDelegPerCycle;
 rewards_amt_deleg[ssn_operator][deleg] := uint128_zero;
 forall combined_args_list CalcRewardsDelegPerCycle;
 reward <- rewards_amt_deleg[ssn_operator][deleg];
@@ -537,9 +538,7 @@ ssn = Ssn active_status stake_amt rest_rewards name urlraw urlapi buffdeposit co
 ssnlist[ssn_operator] := ssn
 | None =>
 end;
-sdpc <- stake_deleg_per_cycle;
-sdpc_list = builtin to_list sdpc;
-e = { _eventname: "WithdrawalStakeRewards"; reward_list_need: list_need_compute_rewards; combined_args_list: combined_args_list; stake_deleg_per_cycle: sdpc_list };
+e = { _eventname: "WithdrawalStakeRewards"; reward_list_need: list_need_compute_rewards; combined_args_list: combined_args_list };
 event e;
 last_withdraw_cycle_deleg[deleg][ssn_operator] := lrc
 end
@@ -559,7 +558,6 @@ match active_status with
 | True  =>
 last_buf_deposit_cycle_deleg[initiator][ssnaddr] := lrc;
 new_buff_amt  = builtin add amount buffdeposit;
-new_stake_amt = builtin add new_buff_amt stake_amt;
 ssn = Ssn bool_active stake_amt rewards name urlraw urlapi new_buff_amt comm comm_rewards rec_addr;
 ssnlist[ssnaddr] := ssn;
 stake_amt_for_deleg_option  <- buff_deposit_deleg[initiator][ssnaddr][lrc];


### PR DESCRIPTION
(* Don't merge this PR for now, solving the list issue *)

This PR is to fix rewards calculation issue due to the confusing concept of reward cycle, so I make following assumes:

1. When verifier invokes  `AssignStakeReward`, we first increase `lastrewardcycle` to cycle N, then update rewards (and delegates) for those ssn operators at cycle N.

2. When we calculate stake delegate for a specific delegator on a particular ssn operator at cycle N, we are using formula:

`stake_delegate_of_cycle_N = stake_delegate_of_cycle_N-1 + direct_deposit_deleg[N-1] + buff_deposit_deleg[N-2]`

(procedure CalcStakeDelegPerCycle)
(https://github.com/Zilliqa/zil-stake-js/blob/master/src/calculator.ts#L58)

3. When we compute rewards for a specific delegator on a particular ssn operator at cycle N, we are using:

`rewards_of_cycle_N = stake_delegate_of_cycle_N * total_rewards_for_that_ssn_at_cycle_N / total_delegate_on_that_ssn_at_cycle_N`

(procedure CalcRewardsDelegPerCycle)
(https://github.com/Zilliqa/zil-stake-js/blob/master/src/calculator.ts#L99)


Further optimization:

Add a new map `deleg_stake_per_cycle` to record `stake_delegate_of_cycle_N`, it will be computed based on `list_need_compute_rewards` which is limited not `reward_cycle_list`.

