### PR TITLE
fix/rewardscalculation

### DIFF
--- a/contracts/gzil.scilla
+++ b/contracts/gzil.scilla
@@ -55,7 +55,6 @@ let get_val =
 contract GZIL
 (
   contract_owner: ByStr20,
-  proxy_address: ByStr20,
   init_minter: ByStr20,
   name: String,
   symbol: String,
@@ -89,17 +88,6 @@ procedure IsOwner(address: ByStr20)
   | False =>
     err = CodeNotOwner;
     ThrowError err
-  end
-end
-
-(* Check is the caller is the proxy *)
-procedure IsProxy()
-  is_proxy = builtin eq _sender proxy_address;
-  match is_proxy with
-  | True  =>
-  | False =>
-    e = CodeNotProxy;
-    ThrowError e
   end
 end
 
@@ -167,9 +155,8 @@ end
 (***************************************)
 (*             Transitions             *)
 (***************************************)
-transition ChangeMinter(new_minter: ByStr20, initiator: ByStr20)
-  IsProxy;
-  IsOwner initiator;
+transition ChangeMinter(new_minter: ByStr20)
+  IsOwner _sender;
   minter := new_minter;
   e = {_eventname: "ChangedMinter"; new_minter: new_minter};
   event e  

--- a/contracts/proxy.scilla
+++ b/contracts/proxy.scilla
@@ -329,15 +329,9 @@ transition PopulateTotalStakeAmt(amt: Uint128)
     current_impl <- implementation;
     msg = {_tag: "PopulateTotalStakeAmt"; _recipient: current_impl; _amount: zero; amt: amt; initiator: _sender};
     msgs = one_msg msg;
-send msgs
-end
-
-transition UpdateRewardCycleList(list: List Uint128, last_cycle: Uint128)
-    current_impl <- implementation;
-    msg = {_tag: "UpdateRewardCycleList"; _recipient: current_impl; _amount: zero; list: list; last_cycle: last_cycle; initiator: _sender};
-    msgs = one_msg msg;
     send msgs
 end
+
 
 (* @dev: Remove a specific ssn from ssnlist. Used by Admin only. *)
 (* @param ssnaddr: Address of the ssn to be removed *)

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -338,6 +338,9 @@ procedure DecreaseTotalStakeAmt(amt: Uint128)
   valid = uint128_le amt current_amt;
   match valid with
   | True =>
+    current_amt <- totalstakeamount;
+    new_amt = builtin sub current_amt amt;
+    totalstakeamount := new_amt
   | False =>
     e = InvalidTotalAmt;
     ThrowError e

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -149,7 +149,7 @@ let change_rate =
 
 let iota : Uint32 -> Uint32 -> List Uint32 =
   fun (m : Uint32) => fun (n : Uint32) =>
-    let m_lt_n = uint32_le m n in
+    let m_lt_n = builtin lt m n in
     match m_lt_n with
     | True =>
         let delta = builtin sub n m in
@@ -724,15 +724,16 @@ procedure WithdrawalStakeRewards(deleg: ByStr20, ssn_operator: ByStr20)
   last_withdraw_cycle_deleg_m <- last_withdraw_cycle_deleg[deleg][ssn_operator];
   last_withdraw_cycle = option_uint32_value last_withdraw_cycle_deleg_m;
   lrc <- lastrewardcycle;
-  list_need_compute_rewards = iota last_withdraw_cycle lrc;
+
+  m = builtin add last_withdraw_cycle uint32_one;
+  n = builtin add lrc uint32_one;
+  list_need_compute_rewards = iota m n;
   
-  list_reverse_uint32 = @list_reverse Uint32;
-  list_need_compute_rewards_reverse = list_reverse_uint32 list_need_compute_rewards;
   (* Combine deleg and ssn_operator with list_need_compute_rewards *)
   mapper = @list_map Uint32 TmpArg;
   f = fun (cycle: Uint32) => TmpArg deleg ssn_operator cycle;
 
-  list_need_compute_rewards_t = mapper f list_need_compute_rewards_reverse;
+  list_need_compute_rewards_t = mapper f list_need_compute_rewards;
   forall list_need_compute_rewards_t CalcStakeDelegPerCycle;
 
   (* Calculate rewards *)

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -76,7 +76,7 @@ type SSNCycleInfo =
 (* deleg, ssn_operator, reward_cycle *)
 
 type TmpArg =
-| TmpArg of ByStr20 ByStr20 Uint128
+| TmpArg of ByStr20 ByStr20 Uint32
 
 let one_msg =
   fun (m : Message) =>
@@ -85,19 +85,12 @@ let one_msg =
 
 let uint128_one =  Uint128 1
 let uint128_zero = Uint128 0
+let uint128_10_power_7 = Uint128 10000000
+let uint128_100 = Uint128 100
 
-(* left < element <= right *)
-(* This function is used for filting out those cycles that need to compute rewards for delegs *)
-let list_filter_between =
-  fun (left: Uint128) =>
-  fun (right: Uint128) =>
-  fun (l: List Uint128) =>
-    let fil = @list_filter Uint128 in
-    let f = fun (element: Uint128) =>
-      let res_l = builtin lt left element in
-      let res_r = uint128_le element right in
-      andb res_l res_r
-    in fil f l
+let uint32_one = Uint32 1
+let uint32_zero = Uint32 0
+
 
 let option_value =
   tfun 'A =>
@@ -116,15 +109,19 @@ let option_map_uint128_uint128_value =
 let option_uint128_value =
   let f = @option_value Uint128 in
   f uint128_zero
+  
+let option_uint32_value =
+  let f = @option_value Uint32 in
+  f uint32_zero
 
 let sub_one_to_zero =
-  fun (x: Uint128) =>
-  let less_than_one = builtin lt x uint128_one in
+  fun (x: Uint32) =>
+  let less_than_one = builtin lt x uint32_one in
   match less_than_one with
   | True =>
-    uint128_zero
+    uint32_zero
   | False =>
-    let res = builtin sub x uint128_one in
+    let res = builtin sub x uint32_one in
     res
   end
 
@@ -150,10 +147,34 @@ let change_rate =
       builtin sub old new
     end
 
+let iota : Uint32 -> Uint32 -> List Uint32 =
+  fun (m : Uint32) => fun (n : Uint32) =>
+    let m_lt_n = uint32_le m n in
+    match m_lt_n with
+    | True =>
+        let delta = builtin sub n m in
+        let delta_nat = builtin to_nat delta in
+        let fold = @nat_fold (List Uint32) in
+        let nil = Nil {Uint32} in
+        let acc_init = Pair {(List Uint32) Uint32} nil n in
+        let one = Uint32 1 in
+        let step = fun (xs_n : Pair (List Uint32) Uint32) => fun (ignore : Nat) =>
+          match xs_n with
+          | Pair xs n =>
+              let new_n = builtin sub n one in
+              let new_xs = Cons {Uint32} new_n xs in
+              Pair {(List Uint32) Uint32} new_xs new_n
+          end in
+        let fold = @nat_fold (Pair (List Uint32) Uint32) in
+        let xs_m = fold step acc_init delta_nat in
+        match xs_m with
+        | Pair xs m => xs
+        end
+    | False => Nil {Uint32}
+    end
+
 let bool_active = True
 let bool_inactive = False
-let uint128_10_power_7 = Uint128 10000000
-let uint128_100 = Uint128 100
 let addfunds_tag = "AddFunds"
 
 type Error =
@@ -218,7 +239,7 @@ field ssnlist: Map ByStr20 Ssn = Emp ByStr20 Ssn
 
 (* Record commmission for SSN for each reward cycle *)
 (* AddressofSSN -> (RewardCycle -> commission ) *)
-field comm_for_ssn: Map ByStr20 (Map Uint128 Uint128) = Emp ByStr20 (Map Uint128 Uint128)
+field comm_for_ssn: Map ByStr20 (Map Uint32 Uint128) = Emp ByStr20 (Map Uint32 Uint128)
 
 (* Following data structure helps to calculate rewards for delegators *)
 (* Keeps track of stakes deposited at SSNs *)
@@ -232,27 +253,27 @@ field ssn_deleg_amt: Map ByStr20 (Map ByStr20 Uint128) = Emp ByStr20 (Map ByStr2
 (* Keeps track of buffered deposit for a delegator *)
 (* AddressOfDeleg -> (AddressofSSN -> (RewardCycleNumber -> BufferedStakeAmountDuringTheCycle)) *)
 (* The BufferedStakeAmount will only be truely delegated at next cycle *)
-field buff_deposit_deleg: Map ByStr20 (Map ByStr20 (Map Uint128 Uint128)) = Emp ByStr20 (Map ByStr20 (Map Uint128 Uint128))
+field buff_deposit_deleg: Map ByStr20 (Map ByStr20 (Map Uint32 Uint128)) = Emp ByStr20 (Map ByStr20 (Map Uint32 Uint128))
 
 (* Keeps track of stake deposits for a delegator that can be considered for reward calcuation *)
 (* AddressofDeleg -> (AddressofSSN -> (RewardCycleNumber -> StakeAmount)) *)
-field direct_deposit_deleg: Map ByStr20 (Map ByStr20 (Map Uint128 Uint128)) = Emp ByStr20 (Map ByStr20 (Map Uint128 Uint128))
+field direct_deposit_deleg: Map ByStr20 (Map ByStr20 (Map Uint32 Uint128)) = Emp ByStr20 (Map ByStr20 (Map Uint32 Uint128))
 
 (* Keeps track of the cycle number when a deleg last withdrew its rewards *)
 (* AddressOfDeleg -> ( AddressOfSSN -> CycleNumberWhenLastWithdrawn) *)
 (* notice here, the last withdraw cycle also indicated the earlist deposit cycle this round *)
 (* this will help reduce some calculation for DistributeStakeRewards, also can avoid some corner cases *)
-field last_withdraw_cycle_deleg: Map ByStr20 (Map ByStr20 Uint128) = Emp ByStr20 (Map ByStr20 Uint128)
+field last_withdraw_cycle_deleg: Map ByStr20 (Map ByStr20 Uint32) = Emp ByStr20 (Map ByStr20 Uint32)
 
 (* Keeps track of the cycle number when a deleg last buffered deposit its delegate *)
 (* AddressOfDeleg -> ( AddressOfSSN -> CycleNumberWhenLastDeposit) *)
-field last_buf_deposit_cycle_deleg: Map ByStr20 (Map ByStr20 Uint128) = Emp ByStr20 (Map ByStr20 Uint128)
+field last_buf_deposit_cycle_deleg: Map ByStr20 (Map ByStr20 Uint32) = Emp ByStr20 (Map ByStr20 Uint32)
 
 (* AddressOfSSN -> (RewardCycleNumber -> Pair (TotalStakeDuringTheCycleForSSN, TotalRewardEarnedDuringTheCycle) *)
-field stake_ssn_per_cycle: Map ByStr20 (Map Uint128 SSNCycleInfo) = Emp ByStr20 (Map Uint128 SSNCycleInfo)
+field stake_ssn_per_cycle: Map ByStr20 (Map Uint32 SSNCycleInfo) = Emp ByStr20 (Map Uint32 SSNCycleInfo)
 
 (* AddressOfDeleg -> AddressOfSSN -> EffectCycleNum -> Deposit *)
-field deleg_stake_per_cycle: Map ByStr20 (Map ByStr20 (Map Uint128 Uint128)) = Emp ByStr20 (Map ByStr20 (Map Uint128 Uint128))
+field deleg_stake_per_cycle: Map ByStr20 (Map ByStr20 (Map Uint32 Uint128)) = Emp ByStr20 (Map ByStr20 (Map Uint32 Uint128))
 
 field withdrawal_pending: Map ByStr20 (Map BNum Uint128) = Emp ByStr20 (Map BNum Uint128)
 
@@ -264,7 +285,6 @@ field rewards_amt_deleg: Map ByStr20 (Map ByStr20 Uint128) = Emp ByStr20 (Map By
 field avaiable_withdrawal: Uint128 = uint128_zero
 field current_deleg: Option ByStr20 = None {ByStr20}
 
-field reward_cycle_list: List Uint128   =  Nil {Uint128}
 field verifier: Option ByStr20 = None {ByStr20}
 field verifier_receiving_addr: Option ByStr20 = None {ByStr20}
 
@@ -277,7 +297,7 @@ field mindelegstake: Uint128 = Uint128 1000000000000000
 field contractadmin: ByStr20  = init_admin
 field proxyaddr: ByStr20 = init_proxy_address
 field gziladdr: ByStr20 = gzil_address
-field lastrewardcycle: Uint128 = uint128_one
+field lastrewardcycle: Uint32 = uint32_one
 field paused: Bool = True
 
 (* 1% *)
@@ -540,7 +560,7 @@ end
 
 procedure HasRewardToWithdraw(ssnaddr: ByStr20, deleg: ByStr20)
   lrcd_tmp <- last_withdraw_cycle_deleg[deleg][ssnaddr];
-  lrcd = option_uint128_value lrcd_tmp;
+  lrcd = option_uint32_value lrcd_tmp;
   lrc <- lastrewardcycle;
   has_reward = builtin lt lrcd lrc;
   match has_reward with
@@ -553,10 +573,10 @@ end
 
 procedure HasBufferedDeposit(ssnaddr: ByStr20, deleg: ByStr20)
   ldcd_o <- last_buf_deposit_cycle_deleg[deleg][ssnaddr];
-  ldcd = option_uint128_value ldcd_o;
+  ldcd = option_uint32_value ldcd_o;
   lrc <- lastrewardcycle;
   (* in fact, lrc will only more than or equal to ldcd, equal means he delegates this around and withdraw this around as well *)
-  has_buffered = uint128_le lrc ldcd;
+  has_buffered = uint32_le lrc ldcd;
   match has_buffered with
   | True =>
     e = DelegHasBufferedDeposit;
@@ -646,7 +666,7 @@ end
 procedure CalcStakeDelegPerCycle(tmp_arg: TmpArg)
   match tmp_arg with
   | TmpArg deleg ssn_operator reward_cycle =>
-    last_reward_cycle = builtin sub reward_cycle uint128_one;
+    last_reward_cycle = builtin sub reward_cycle uint32_one;
     last2_reward_cycle = sub_one_to_zero last_reward_cycle;
     cur_opt <- direct_deposit_deleg[deleg][ssn_operator][last_reward_cycle];
     buf_opt <- buff_deposit_deleg[deleg][ssn_operator][last2_reward_cycle];
@@ -702,25 +722,21 @@ end
 
 procedure WithdrawalStakeRewards(deleg: ByStr20, ssn_operator: ByStr20)
   last_withdraw_cycle_deleg_m <- last_withdraw_cycle_deleg[deleg][ssn_operator];
-  last_withdraw_cycle = option_uint128_value last_withdraw_cycle_deleg_m;
+  last_withdraw_cycle = option_uint32_value last_withdraw_cycle_deleg_m;
   lrc <- lastrewardcycle;
-  rcl <- reward_cycle_list;
-  list_reverse_uint128 = @list_reverse Uint128;
-  rcl_reverse = list_reverse_uint128 rcl;
-  (* those are the cycles that we want to compute for computing rewards *)
-  list_need_compute_rewards = list_filter_between last_withdraw_cycle lrc rcl;
+  list_need_compute_rewards = iota last_withdraw_cycle lrc;
   
-  list_reverse_uint128 = @list_reverse Uint128;
-  list_need_compute_rewards_reverse = list_reverse_uint128 list_need_compute_rewards;
+  list_reverse_uint32 = @list_reverse Uint32;
+  list_need_compute_rewards_reverse = list_reverse_uint32 list_need_compute_rewards;
   (* Combine deleg and ssn_operator with list_need_compute_rewards *)
-  mapper = @list_map Uint128 TmpArg;
-  f = fun (cycle: Uint128) => TmpArg deleg ssn_operator cycle;
-  combined_args_list = mapper f list_need_compute_rewards;
+  mapper = @list_map Uint32 TmpArg;
+  f = fun (cycle: Uint32) => TmpArg deleg ssn_operator cycle;
 
   list_need_compute_rewards_t = mapper f list_need_compute_rewards_reverse;
   forall list_need_compute_rewards_t CalcStakeDelegPerCycle;
 
   (* Calculate rewards *)
+  combined_args_list = mapper f list_need_compute_rewards;
   rewards_amt_deleg[ssn_operator][deleg] := uint128_zero;
   forall combined_args_list CalcRewardsDelegPerCycle;
 
@@ -1037,8 +1053,6 @@ transition WithdrawStakeRewards(ssn_operator: ByStr20, initiator: ByStr20)
   IsPaused;
   IsProxy;
   DelegExists ssn_operator initiator;
-  amt_opt <- deposit_amt_deleg[initiator][ssn_operator];
-  amt = option_uint128_value amt_opt;
   WithdrawalStakeRewards initiator ssn_operator
 end
 
@@ -1096,11 +1110,8 @@ transition AssignStakeReward(ssnreward_list: List SsnRewardShare, verifier_rewar
   IsProxy;
   CallerIsVerifier initiator;
   lrc <- lastrewardcycle;
-  newLastRewardCycleNum = builtin add uint128_one lrc;
+  newLastRewardCycleNum = builtin add uint32_one lrc;
   lastrewardcycle := newLastRewardCycleNum;
-  rcl <- reward_cycle_list;
-  rcl_new = Cons {Uint128} newLastRewardCycleNum rcl;
-  reward_cycle_list := rcl_new;
   forall ssnreward_list UpdateStakeReward;
   verifier_o <- verifier_receiving_addr;
   match verifier_o with
@@ -1174,7 +1185,7 @@ end
 (* @param stake_amt: Stake amount *)
 (* @param initiator: The original caller who called the proxy *)
 (* Its very crucial that after this operation, we should recovery direct and buffered map, as well as *)
-(* lastrewardcycle reward_cycle_list last_withdraw_cycle_deleg last_buf_deposit_cycle_deleg totalstakeamount *)
+(* lastrewardcycle last_withdraw_cycle_deleg last_buf_deposit_cycle_deleg totalstakeamount *)
 transition UpdateDeleg(ssnaddr: ByStr20, deleg: ByStr20, stake_amt: Uint128, initiator: ByStr20)
   IsProxy;
   IsAdmin initiator;
@@ -1212,31 +1223,31 @@ transition UpdateDeleg(ssnaddr: ByStr20, deleg: ByStr20, stake_amt: Uint128, ini
   end
 end
 
-transition PopulateStakeSSNPerCycle(ssn_addr: ByStr20, cycle: Uint128, info: SSNCycleInfo, initiator: ByStr20)
+transition PopulateStakeSSNPerCycle(ssn_addr: ByStr20, cycle: Uint32, info: SSNCycleInfo, initiator: ByStr20)
   IsProxy;
   IsAdmin initiator;
   stake_ssn_per_cycle[ssn_addr][cycle] := info
 end
 
-transition PopulateLastWithdrawCycleForDeleg(deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint128, initiator: ByStr20)
+transition PopulateLastWithdrawCycleForDeleg(deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint32, initiator: ByStr20)
   IsProxy;
   IsAdmin initiator;
   last_withdraw_cycle_deleg[deleg_addr][ssn_addr] := cycle
 end
 
-transition PopulateBuffDeposit(deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint128, amt: Uint128, initiator: ByStr20)
+transition PopulateBuffDeposit(deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint32, amt: Uint128, initiator: ByStr20)
   IsProxy;
   IsAdmin initiator;
   buff_deposit_deleg[deleg_addr][ssn_addr][cycle] := amt
 end
 
-transition PopulateDirectDeposit(deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint128, amt: Uint128, initiator: ByStr20)
+transition PopulateDirectDeposit(deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint32, amt: Uint128, initiator: ByStr20)
   IsProxy;
   IsAdmin initiator;
   direct_deposit_deleg[deleg_addr][ssn_addr][cycle] := amt
 end
 
-transition PopulateCommForSSN(ssn_addr: ByStr20, cycle: Uint128, comm: Uint128, initiator: ByStr20)
+transition PopulateCommForSSN(ssn_addr: ByStr20, cycle: Uint32, comm: Uint128, initiator: ByStr20)
   IsProxy;
   IsAdmin initiator;
   comm_for_ssn[ssn_addr][cycle] := comm
@@ -1246,17 +1257,6 @@ transition PopulateTotalStakeAmt(amt: Uint128, initiator: ByStr20)
   IsProxy;
   IsAdmin initiator;
   totalstakeamount := amt
-end
-
-(* @dev: Update reward cycle list and last reward cycle *)
-(* @param list: reward cycle list *)
-(* @param last_cycle: last reward cycle *)
-(* @param initiator: The original caller who called the proxy *)
-transition UpdateRewardCycleList(list: List Uint128, last_cycle: Uint128, initiator: ByStr20)
-  IsProxy;
-  IsAdmin initiator;
-  reward_cycle_list := list;
-  lastrewardcycle := last_cycle
 end
 
 (* @dev:  Drain the contract's balance. Used by current admin only *)

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -42,8 +42,8 @@ type Ssn =
 (*  SSNAddress        : ByStr20 *)
 (*                      Address of the SSN. *)
 (*  CycleReward       : Uint128 *)
-(*                      Integer representation of reward assigned by the verifier to this SSN for this cycle. 
-(*                      It's floor(NumberOfDSEpochsInCurrentCycle * 110,000 * VerificationPassed)
+(*                      Integer representation of reward assigned by the verifier to this SSN for this cycle. *)
+(*                      It's floor(NumberOfDSEpochsInCurrentCycle * 110,000 * VerificationPassed) *)
 (* https://github.com/Zilliqa/ZIP/blob/zip-11-author-fix/zips/zip-11.md#verifier *)
 
 type SsnRewardShare =
@@ -175,7 +175,6 @@ type Error =
   | InvalidTotalAmt
   | InvalidRecvAddr
   | VerifierNotSet
-  | NotTimeYet
   | VerifierRecvAddrNotSet
 
 let make_error =
@@ -679,10 +678,9 @@ end
 procedure CalcRewardsDelegPerCycle(tmp_arg: TmpArg)
   match tmp_arg with
   | TmpArg deleg ssn_operator reward_cycle =>
-    (* Calculate staking rewards per cycle for deleg - this replaces calculate_rewards_per_cycle_for_deleg *)
+    (* Calculate staking rewards per cycle for deleg *)
     staking_per_cycle_for_deleg_opt <- stake_deleg_per_cycle[reward_cycle];
-    lrc = builtin sub reward_cycle uint128_one;
-    staking_and_rewards_per_cycle_for_ssn_opt <- stake_ssn_per_cycle[ssn_operator][lrc];
+    staking_and_rewards_per_cycle_for_ssn_opt <- stake_ssn_per_cycle[ssn_operator][reward_cycle];
     match staking_per_cycle_for_deleg_opt with
     | Some staking_of_deleg =>
       match staking_and_rewards_per_cycle_for_ssn_opt with
@@ -1087,12 +1085,12 @@ transition AssignStakeReward(ssnreward_list: List SsnRewardShare, verifier_rewar
   IsProxy;
   CallerIsVerifier initiator;
   lrc <- lastrewardcycle;
-  forall ssnreward_list UpdateStakeReward;
   newLastRewardCycleNum = builtin add uint128_one lrc;
   lastrewardcycle := newLastRewardCycleNum;
   rcl <- reward_cycle_list;
   rcl_new = Cons {Uint128} newLastRewardCycleNum rcl;
   reward_cycle_list := rcl_new;
+  forall ssnreward_list UpdateStakeReward;
   verifier_o <- verifier_receiving_addr;
   match verifier_o with
   | Some v => 

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -624,6 +624,38 @@ procedure AdjustDeleg(ssnaddr: ByStr20, deleg: ByStr20, total_amount: Uint128, w
   end
 end
 
+procedure ReDelegStakeAmt(initiator: ByStr20, ssn: ByStr20, redeleg_amt: Uint128)
+  ssn_o <- ssnlist[ssn];
+  deleg <- deposit_amt_deleg[initiator][ssn];
+  lrc <- lastrewardcycle;
+  match ssn_o with
+  | Some (Ssn active_status stake_amt rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr) =>
+    match deleg with
+    | Some amt =>
+      HasRewardToWithdraw ssn initiator;
+      HasBufferedDeposit ssn initiator;
+      AdjustDeleg ssn initiator amt redeleg_amt;
+      (* Illegal withdraw amount could be handled in procedure AdjustDeleg *)
+      DecreaseTotalStakeAmt redeleg_amt;
+      new_amt = builtin sub stake_amt redeleg_amt;
+      minstake_tmp <- minstake;
+      status = uint128_le minstake_tmp new_amt;
+      ssn_option_tmp = Ssn status new_amt rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr;
+      ssnlist[ssn] := ssn_option_tmp;
+      (* If ssn becomes inactive, we need to decrease the rest ones also *)
+      DecreaseTotalStakeAmtOnStatus new_amt status;
+      e = { _eventname: "Remove delegate from SSN"; ssn_addr: ssn; deleg_address: initiator; amt: redeleg_amt };
+      event e
+    | None =>
+      e = DelegDoesNotExistAtSSN;
+      ThrowError e
+    end
+  | None =>
+    e = SSNNotExist;
+    ThrowError e
+  end
+end
+
 procedure WithdrawalStakeAmt(initiator: ByStr20, ssn: ByStr20, withdraw_amount: Uint128)
   ssn_o <- ssnlist[ssn];
   deleg <- deposit_amt_deleg[initiator][ssn];
@@ -1093,7 +1125,7 @@ end
 transition ReDelegateStake(ssnaddr: ByStr20, to_ssn: ByStr20, amount: Uint128, initiator: ByStr20)
   IsPaused;
   IsProxy;
-  WithdrawalStakeAmt initiator ssnaddr amount;
+  ReDelegStakeAmt initiator ssnaddr amount;
   Delegate to_ssn initiator amount;
   e = { _eventname: "ReDelegateStakeSuccess"; ssnaddr: ssnaddr; to_ssn: to_ssn; delegator: initiator; delegate_amount: amount };
   event e

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -251,13 +251,14 @@ field last_buf_deposit_cycle_deleg: Map ByStr20 (Map ByStr20 Uint128) = Emp BySt
 (* AddressOfSSN -> (RewardCycleNumber -> Pair (TotalStakeDuringTheCycleForSSN, TotalRewardEarnedDuringTheCycle) *)
 field stake_ssn_per_cycle: Map ByStr20 (Map Uint128 SSNCycleInfo) = Emp ByStr20 (Map Uint128 SSNCycleInfo)
 
+(* AddressOfDeleg -> AddressOfSSN -> EffectCycleNum -> Deposit *)
+field deleg_stake_per_cycle: Map ByStr20 (Map ByStr20 (Map Uint128 Uint128)) = Emp ByStr20 (Map ByStr20 (Map Uint128 Uint128))
+
 field withdrawal_pending: Map ByStr20 (Map BNum Uint128) = Emp ByStr20 (Map BNum Uint128)
 
 field bnum_req: Uint128 = Uint128 24000
 
 (* Temporary storage maps *)
-(* Used during CalcStakeDelegPerCycle *)
-field stake_deleg_per_cycle: Map Uint128 Uint128 = Emp Uint128 Uint128
 (* Used during CalcRewardsDelegPerCycle *)
 field rewards_amt_deleg: Map ByStr20 (Map ByStr20 Uint128) = Emp ByStr20 (Map ByStr20 Uint128)
 field avaiable_withdrawal: Uint128 = uint128_zero
@@ -642,20 +643,21 @@ end
 procedure CalcStakeDelegPerCycle(tmp_arg: TmpArg)
   match tmp_arg with
   | TmpArg deleg ssn_operator reward_cycle =>
-    (* Combine buffered and direct - this replaces combine_buffered_and_direct *)
     last_reward_cycle = builtin sub reward_cycle uint128_one;
     last2_reward_cycle = sub_one_to_zero last_reward_cycle;
     cur_opt <- direct_deposit_deleg[deleg][ssn_operator][last_reward_cycle];
     buf_opt <- buff_deposit_deleg[deleg][ssn_operator][last2_reward_cycle];
     comb_opt = option_add cur_opt buf_opt;
-    (* Calculate final staking per cycle for delegs - this replaces calculate_all_stake_pr_cycle *)
-    result_map_opt <- stake_deleg_per_cycle[last_reward_cycle];
-    stake_opt = option_add comb_opt result_map_opt;
-    match stake_opt with
+
+    last_amt_o <- deleg_stake_per_cycle[deleg][ssn_operator][last_reward_cycle];
+    last_amt = option_uint128_value last_amt_o;
+    
+    match comb_opt with
     | Some stake =>
-      stake_deleg_per_cycle[reward_cycle] := stake
+      total_stake = builtin add last_amt stake;
+      deleg_stake_per_cycle[deleg][ssn_operator][reward_cycle] := total_stake
     | None =>
-      stake_deleg_per_cycle[reward_cycle] := uint128_zero
+      deleg_stake_per_cycle[deleg][ssn_operator][reward_cycle] := last_amt
     end
   end
 end
@@ -679,7 +681,7 @@ procedure CalcRewardsDelegPerCycle(tmp_arg: TmpArg)
   match tmp_arg with
   | TmpArg deleg ssn_operator reward_cycle =>
     (* Calculate staking rewards per cycle for deleg *)
-    staking_per_cycle_for_deleg_opt <- stake_deleg_per_cycle[reward_cycle];
+    staking_per_cycle_for_deleg_opt <- deleg_stake_per_cycle[deleg][ssn_operator][reward_cycle];
     staking_and_rewards_per_cycle_for_ssn_opt <- stake_ssn_per_cycle[ssn_operator][reward_cycle];
     match staking_per_cycle_for_deleg_opt with
     | Some staking_of_deleg =>
@@ -704,17 +706,16 @@ procedure WithdrawalStakeRewards(deleg: ByStr20, ssn_operator: ByStr20)
   rcl_reverse = list_reverse_uint128 rcl;
   (* those are the cycles that we want to compute for computing rewards *)
   list_need_compute_rewards = list_filter_between last_withdraw_cycle lrc rcl;
+  
+  list_reverse_uint128 = @list_reverse Uint128;
+  list_need_compute_rewards_reverse = list_reverse_uint128 list_need_compute_rewards;
   (* Combine deleg and ssn_operator with list_need_compute_rewards *)
   mapper = @list_map Uint128 TmpArg;
   f = fun (cycle: Uint128) => TmpArg deleg ssn_operator cycle;
   combined_args_list = mapper f list_need_compute_rewards;
 
-
-  (* calculate stake_deleg_per_cycle *)
-  emp_map = Emp Uint128 Uint128;
-  stake_deleg_per_cycle := emp_map;
-  rcl_reverse_t = mapper f rcl_reverse;
-  forall rcl_reverse_t CalcStakeDelegPerCycle;
+  list_need_compute_rewards_t = mapper f list_need_compute_rewards_reverse;
+  forall list_need_compute_rewards_t CalcStakeDelegPerCycle;
 
   (* Calculate rewards *)
   rewards_amt_deleg[ssn_operator][deleg] := uint128_zero;
@@ -725,9 +726,16 @@ procedure WithdrawalStakeRewards(deleg: ByStr20, ssn_operator: ByStr20)
   reward = option_uint128_value reward;
   SendDelegRewards deleg reward;
   MintCall deleg reward;
-  sdpc <- stake_deleg_per_cycle;
-  sdpc_list = builtin to_list sdpc;
-  e = { _eventname: "WithdrawalStakeRewards"; reward_list_need: list_need_compute_rewards; combined_args_list: combined_args_list; stake_deleg_per_cycle: sdpc_list };
+
+  ssn_o <- ssnlist[ssn_operator];
+  match ssn_o with
+  | Some (Ssn active_status stake_amt total_rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr) =>
+    rest_rewards = builtin sub total_rewards reward;
+    ssn = Ssn active_status stake_amt rest_rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr;
+    ssnlist[ssn_operator] := ssn
+  | None => (* won't reach *)
+  end;
+  e = { _eventname: "WithdrawalStakeRewards"; reward_list_need: list_need_compute_rewards; combined_args_list: combined_args_list };
   event e;
   last_withdraw_cycle_deleg[deleg][ssn_operator] := lrc
 end

--- a/tests/ssnlist.scilla
+++ b/tests/ssnlist.scilla
@@ -446,6 +446,35 @@ e = DelegHasNoSufficientAmt;
 ThrowError e
 end
 end
+procedure ReDelegStakeAmt(initiator: ByStr20, ssn: ByStr20, redeleg_amt: Uint128)
+ssn_o <- ssnlist[ssn];
+deleg <- deposit_amt_deleg[initiator][ssn];
+lrc <- lastrewardcycle;
+match ssn_o with
+| Some (Ssn active_status stake_amt rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr) =>
+match deleg with
+| Some amt =>
+HasRewardToWithdraw ssn initiator;
+HasBufferedDeposit ssn initiator;
+AdjustDeleg ssn initiator amt redeleg_amt;
+DecreaseTotalStakeAmt redeleg_amt;
+new_amt = builtin sub stake_amt redeleg_amt;
+minstake_tmp <- minstake;
+status = uint128_le minstake_tmp new_amt;
+ssn_option_tmp = Ssn status new_amt rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr;
+ssnlist[ssn] := ssn_option_tmp;
+DecreaseTotalStakeAmtOnStatus new_amt status;
+e = { _eventname: "Remove delegate from SSN"; ssn_addr: ssn; deleg_address: initiator; amt: redeleg_amt };
+event e
+| None =>
+e = DelegDoesNotExistAtSSN;
+ThrowError e
+end
+| None =>
+e = SSNNotExist;
+ThrowError e
+end
+end
 procedure WithdrawalStakeAmt(initiator: ByStr20, ssn: ByStr20, withdraw_amount: Uint128)
 ssn_o <- ssnlist[ssn];
 deleg <- deposit_amt_deleg[initiator][ssn];
@@ -807,7 +836,7 @@ end
 transition ReDelegateStake(ssnaddr: ByStr20, to_ssn: ByStr20, amount: Uint128, initiator: ByStr20)
 IsPaused;
 IsProxy;
-WithdrawalStakeAmt initiator ssnaddr amount;
+ReDelegStakeAmt initiator ssnaddr amount;
 Delegate to_ssn initiator amount;
 e = { _eventname: "ReDelegateStakeSuccess"; ssnaddr: ssnaddr; to_ssn: to_ssn; delegator: initiator; delegate_amount: amount };
 event e

--- a/tests/ssnlist.scilla
+++ b/tests/ssnlist.scilla
@@ -99,9 +99,12 @@ type Error =
 | InvalidTotalAmt
 | InvalidRecvAddr
 | VerifierNotSet
+<<<<<<< HEAD
 | NotTimeYet
 | NoPendingWithdrawal
 | InvalidWithdrawAmt
+=======
+>>>>>>> 5ea1b34... fix: clarify reward cycle
 | VerifierRecvAddrNotSet
 let make_error =
 fun (result: Error) =>
@@ -427,8 +430,12 @@ TruncateDeleg deleg ssnaddr;
 deposit_amt_deleg[deleg][ssnaddr] := rest_deleg;
 ssn_deleg_amt[ssnaddr][deleg] := rest_deleg;
 direct_deposit_deleg[deleg][ssnaddr][lrc] := rest_deleg;
+<<<<<<< HEAD
 last_withdraw_cycle_deleg[deleg][ssnaddr] := lrc;
 last_buf_deposit_cycle_deleg[deleg][ssnaddr] := lrc
+=======
+last_withdraw_cycle_deleg[deleg][ssnaddr] := lrc
+>>>>>>> 5ea1b34... fix: clarify reward cycle
 end
 | False =>
 e = DelegHasNoSufficientAmt;
@@ -506,8 +513,7 @@ procedure CalcRewardsDelegPerCycle(tmp_arg: TmpArg)
 match tmp_arg with
 | TmpArg deleg ssn_operator reward_cycle =>
 staking_per_cycle_for_deleg_opt <- stake_deleg_per_cycle[reward_cycle];
-lrc = builtin sub reward_cycle uint128_one;
-staking_and_rewards_per_cycle_for_ssn_opt <- stake_ssn_per_cycle[ssn_operator][lrc];
+staking_and_rewards_per_cycle_for_ssn_opt <- stake_ssn_per_cycle[ssn_operator][reward_cycle];
 match staking_per_cycle_for_deleg_opt with
 | Some staking_of_deleg =>
 match staking_and_rewards_per_cycle_for_ssn_opt with
@@ -808,12 +814,12 @@ IsPaused;
 IsProxy;
 CallerIsVerifier initiator;
 lrc <- lastrewardcycle;
-forall ssnreward_list UpdateStakeReward;
 newLastRewardCycleNum = builtin add uint128_one lrc;
 lastrewardcycle := newLastRewardCycleNum;
 rcl <- reward_cycle_list;
 rcl_new = Cons {Uint128} newLastRewardCycleNum rcl;
 reward_cycle_list := rcl_new;
+forall ssnreward_list UpdateStakeReward;
 verifier_o <- verifier_receiving_addr;
 match verifier_o with
 | Some v =>

--- a/tests/ssnlist.scilla
+++ b/tests/ssnlist.scilla
@@ -10,23 +10,17 @@ type DelegCycleInfo =
 type SSNCycleInfo =
 | SSNCycleInfo of Uint128 Uint128
 type TmpArg =
-| TmpArg of ByStr20 ByStr20 Uint128
+| TmpArg of ByStr20 ByStr20 Uint32
 let one_msg =
 fun (m : Message) =>
 let e = Nil {Message} in
 Cons {Message} m e
 let uint128_one =  Uint128 1
 let uint128_zero = Uint128 0
-let list_filter_between =
-fun (left: Uint128) =>
-fun (right: Uint128) =>
-fun (l: List Uint128) =>
-let fil = @list_filter Uint128 in
-let f = fun (element: Uint128) =>
-let res_l = builtin lt left element in
-let res_r = uint128_le element right in
-andb res_l res_r
-in fil f l
+let uint128_10_power_7 = Uint128 10000000
+let uint128_100 = Uint128 100
+let uint32_one = Uint32 1
+let uint32_zero = Uint32 0
 let option_value =
 tfun 'A =>
 fun (default: 'A) =>
@@ -42,14 +36,17 @@ f emt
 let option_uint128_value =
 let f = @option_value Uint128 in
 f uint128_zero
+let option_uint32_value =
+let f = @option_value Uint32 in
+f uint32_zero
 let sub_one_to_zero =
-fun (x: Uint128) =>
-let less_than_one = builtin lt x uint128_one in
+fun (x: Uint32) =>
+let less_than_one = builtin lt x uint32_one in
 match less_than_one with
 | True =>
-uint128_zero
+uint32_zero
 | False =>
-let res = builtin sub x uint128_one in
+let res = builtin sub x uint32_one in
 res
 end
 let option_add =
@@ -72,10 +69,33 @@ builtin sub new old
 | False =>
 builtin sub old new
 end
+let iota : Uint32 -> Uint32 -> List Uint32 =
+fun (m : Uint32) => fun (n : Uint32) =>
+let m_lt_n = uint32_le m n in
+match m_lt_n with
+| True =>
+let delta = builtin sub n m in
+let delta_nat = builtin to_nat delta in
+let fold = @nat_fold (List Uint32) in
+let nil = Nil {Uint32} in
+let acc_init = Pair {(List Uint32) Uint32} nil n in
+let one = Uint32 1 in
+let step = fun (xs_n : Pair (List Uint32) Uint32) => fun (ignore : Nat) =>
+match xs_n with
+| Pair xs n =>
+let new_n = builtin sub n one in
+let new_xs = Cons {Uint32} new_n xs in
+Pair {(List Uint32) Uint32} new_xs new_n
+end in
+let fold = @nat_fold (Pair (List Uint32) Uint32) in
+let xs_m = fold step acc_init delta_nat in
+match xs_m with
+| Pair xs m => xs
+end
+| False => Nil {Uint32}
+end
 let bool_active = True
 let bool_inactive = False
-let uint128_10_power_7 = Uint128 10000000
-let uint128_100 = Uint128 100
 let addfunds_tag = "AddFunds"
 type Error =
 | ContractFrozenFailure
@@ -129,21 +149,20 @@ init_proxy_address: ByStr20,
 gzil_address: ByStr20
 )
 field ssnlist: Map ByStr20 Ssn = Emp ByStr20 Ssn
-field comm_for_ssn: Map ByStr20 (Map Uint128 Uint128) = Emp ByStr20 (Map Uint128 Uint128)
+field comm_for_ssn: Map ByStr20 (Map Uint32 Uint128) = Emp ByStr20 (Map Uint32 Uint128)
 field deposit_amt_deleg: Map ByStr20 (Map ByStr20 Uint128) = Emp ByStr20 (Map ByStr20 Uint128)
 field ssn_deleg_amt: Map ByStr20 (Map ByStr20 Uint128) = Emp ByStr20 (Map ByStr20 Uint128)
-field buff_deposit_deleg: Map ByStr20 (Map ByStr20 (Map Uint128 Uint128)) = Emp ByStr20 (Map ByStr20 (Map Uint128 Uint128))
-field direct_deposit_deleg: Map ByStr20 (Map ByStr20 (Map Uint128 Uint128)) = Emp ByStr20 (Map ByStr20 (Map Uint128 Uint128))
-field last_withdraw_cycle_deleg: Map ByStr20 (Map ByStr20 Uint128) = Emp ByStr20 (Map ByStr20 Uint128)
-field last_buf_deposit_cycle_deleg: Map ByStr20 (Map ByStr20 Uint128) = Emp ByStr20 (Map ByStr20 Uint128)
-field stake_ssn_per_cycle: Map ByStr20 (Map Uint128 SSNCycleInfo) = Emp ByStr20 (Map Uint128 SSNCycleInfo)
-field deleg_stake_per_cycle: Map ByStr20 (Map ByStr20 (Map Uint128 Uint128)) = Emp ByStr20 (Map ByStr20 (Map Uint128 Uint128))
+field buff_deposit_deleg: Map ByStr20 (Map ByStr20 (Map Uint32 Uint128)) = Emp ByStr20 (Map ByStr20 (Map Uint32 Uint128))
+field direct_deposit_deleg: Map ByStr20 (Map ByStr20 (Map Uint32 Uint128)) = Emp ByStr20 (Map ByStr20 (Map Uint32 Uint128))
+field last_withdraw_cycle_deleg: Map ByStr20 (Map ByStr20 Uint32) = Emp ByStr20 (Map ByStr20 Uint32)
+field last_buf_deposit_cycle_deleg: Map ByStr20 (Map ByStr20 Uint32) = Emp ByStr20 (Map ByStr20 Uint32)
+field stake_ssn_per_cycle: Map ByStr20 (Map Uint32 SSNCycleInfo) = Emp ByStr20 (Map Uint32 SSNCycleInfo)
+field deleg_stake_per_cycle: Map ByStr20 (Map ByStr20 (Map Uint32 Uint128)) = Emp ByStr20 (Map ByStr20 (Map Uint32 Uint128))
 field withdrawal_pending: Map ByStr20 (Map BNum Uint128) = Emp ByStr20 (Map BNum Uint128)
 field bnum_req: Uint128 = Uint128 24000
 field rewards_amt_deleg: Map ByStr20 (Map ByStr20 Uint128) = Emp ByStr20 (Map ByStr20 Uint128)
 field avaiable_withdrawal: Uint128 = uint128_zero
 field current_deleg: Option ByStr20 = None {ByStr20}
-field reward_cycle_list: List Uint128   =  Nil {Uint128}
 field verifier: Option ByStr20 = None {ByStr20}
 field verifier_receiving_addr: Option ByStr20 = None {ByStr20}
 field minstake: Uint128 = Uint128 10000000000000000000
@@ -151,7 +170,7 @@ field mindelegstake: Uint128 = Uint128 1000000000000000
 field contractadmin: ByStr20  = init_admin
 field proxyaddr: ByStr20 = init_proxy_address
 field gziladdr: ByStr20 = gzil_address
-field lastrewardcycle: Uint128 = uint128_one
+field lastrewardcycle: Uint32 = uint32_one
 field paused: Bool = True
 field maxcommchangerate: Uint128 = uint128_one
 field maxcommrate: Uint128 = Uint128 1000000000
@@ -372,7 +391,7 @@ end
 end
 procedure HasRewardToWithdraw(ssnaddr: ByStr20, deleg: ByStr20)
 lrcd_tmp <- last_withdraw_cycle_deleg[deleg][ssnaddr];
-lrcd = option_uint128_value lrcd_tmp;
+lrcd = option_uint32_value lrcd_tmp;
 lrc <- lastrewardcycle;
 has_reward = builtin lt lrcd lrc;
 match has_reward with
@@ -384,9 +403,9 @@ end
 end
 procedure HasBufferedDeposit(ssnaddr: ByStr20, deleg: ByStr20)
 ldcd_o <- last_buf_deposit_cycle_deleg[deleg][ssnaddr];
-ldcd = option_uint128_value ldcd_o;
+ldcd = option_uint32_value ldcd_o;
 lrc <- lastrewardcycle;
-has_buffered = uint128_le lrc ldcd;
+has_buffered = uint32_le lrc ldcd;
 match has_buffered with
 | True =>
 e = DelegHasBufferedDeposit;
@@ -466,7 +485,7 @@ end
 procedure CalcStakeDelegPerCycle(tmp_arg: TmpArg)
 match tmp_arg with
 | TmpArg deleg ssn_operator reward_cycle =>
-last_reward_cycle = builtin sub reward_cycle uint128_one;
+last_reward_cycle = builtin sub reward_cycle uint32_one;
 last2_reward_cycle = sub_one_to_zero last_reward_cycle;
 cur_opt <- direct_deposit_deleg[deleg][ssn_operator][last_reward_cycle];
 buf_opt <- buff_deposit_deleg[deleg][ssn_operator][last2_reward_cycle];
@@ -515,19 +534,16 @@ end
 end
 procedure WithdrawalStakeRewards(deleg: ByStr20, ssn_operator: ByStr20)
 last_withdraw_cycle_deleg_m <- last_withdraw_cycle_deleg[deleg][ssn_operator];
-last_withdraw_cycle = option_uint128_value last_withdraw_cycle_deleg_m;
+last_withdraw_cycle = option_uint32_value last_withdraw_cycle_deleg_m;
 lrc <- lastrewardcycle;
-rcl <- reward_cycle_list;
-list_reverse_uint128 = @list_reverse Uint128;
-rcl_reverse = list_reverse_uint128 rcl;
-list_need_compute_rewards = list_filter_between last_withdraw_cycle lrc rcl;
-list_reverse_uint128 = @list_reverse Uint128;
-list_need_compute_rewards_reverse = list_reverse_uint128 list_need_compute_rewards;
-mapper = @list_map Uint128 TmpArg;
-f = fun (cycle: Uint128) => TmpArg deleg ssn_operator cycle;
-combined_args_list = mapper f list_need_compute_rewards;
+list_need_compute_rewards = iota last_withdraw_cycle lrc;
+list_reverse_uint32 = @list_reverse Uint32;
+list_need_compute_rewards_reverse = list_reverse_uint32 list_need_compute_rewards;
+mapper = @list_map Uint32 TmpArg;
+f = fun (cycle: Uint32) => TmpArg deleg ssn_operator cycle;
 list_need_compute_rewards_t = mapper f list_need_compute_rewards_reverse;
 forall list_need_compute_rewards_t CalcStakeDelegPerCycle;
+combined_args_list = mapper f list_need_compute_rewards;
 rewards_amt_deleg[ssn_operator][deleg] := uint128_zero;
 forall combined_args_list CalcRewardsDelegPerCycle;
 reward <- rewards_amt_deleg[ssn_operator][deleg];
@@ -762,8 +778,6 @@ transition WithdrawStakeRewards(ssn_operator: ByStr20, initiator: ByStr20)
 IsPaused;
 IsProxy;
 DelegExists ssn_operator initiator;
-amt_opt <- deposit_amt_deleg[initiator][ssn_operator];
-amt = option_uint128_value amt_opt;
 WithdrawalStakeRewards initiator ssn_operator
 end
 transition WithdrawStakeAmt(ssn: ByStr20, amt: Uint128, initiator: ByStr20)
@@ -803,11 +817,8 @@ IsPaused;
 IsProxy;
 CallerIsVerifier initiator;
 lrc <- lastrewardcycle;
-newLastRewardCycleNum = builtin add uint128_one lrc;
+newLastRewardCycleNum = builtin add uint32_one lrc;
 lastrewardcycle := newLastRewardCycleNum;
-rcl <- reward_cycle_list;
-rcl_new = Cons {Uint128} newLastRewardCycleNum rcl;
-reward_cycle_list := rcl_new;
 forall ssnreward_list UpdateStakeReward;
 verifier_o <- verifier_receiving_addr;
 match verifier_o with
@@ -884,27 +895,27 @@ e = SSNNotExist;
 ThrowError e
 end
 end
-transition PopulateStakeSSNPerCycle(ssn_addr: ByStr20, cycle: Uint128, info: SSNCycleInfo, initiator: ByStr20)
+transition PopulateStakeSSNPerCycle(ssn_addr: ByStr20, cycle: Uint32, info: SSNCycleInfo, initiator: ByStr20)
 IsProxy;
 IsAdmin initiator;
 stake_ssn_per_cycle[ssn_addr][cycle] := info
 end
-transition PopulateLastWithdrawCycleForDeleg(deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint128, initiator: ByStr20)
+transition PopulateLastWithdrawCycleForDeleg(deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint32, initiator: ByStr20)
 IsProxy;
 IsAdmin initiator;
 last_withdraw_cycle_deleg[deleg_addr][ssn_addr] := cycle
 end
-transition PopulateBuffDeposit(deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint128, amt: Uint128, initiator: ByStr20)
+transition PopulateBuffDeposit(deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint32, amt: Uint128, initiator: ByStr20)
 IsProxy;
 IsAdmin initiator;
 buff_deposit_deleg[deleg_addr][ssn_addr][cycle] := amt
 end
-transition PopulateDirectDeposit(deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint128, amt: Uint128, initiator: ByStr20)
+transition PopulateDirectDeposit(deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint32, amt: Uint128, initiator: ByStr20)
 IsProxy;
 IsAdmin initiator;
 direct_deposit_deleg[deleg_addr][ssn_addr][cycle] := amt
 end
-transition PopulateCommForSSN(ssn_addr: ByStr20, cycle: Uint128, comm: Uint128, initiator: ByStr20)
+transition PopulateCommForSSN(ssn_addr: ByStr20, cycle: Uint32, comm: Uint128, initiator: ByStr20)
 IsProxy;
 IsAdmin initiator;
 comm_for_ssn[ssn_addr][cycle] := comm
@@ -913,12 +924,6 @@ transition PopulateTotalStakeAmt(amt: Uint128, initiator: ByStr20)
 IsProxy;
 IsAdmin initiator;
 totalstakeamount := amt
-end
-transition UpdateRewardCycleList(list: List Uint128, last_cycle: Uint128, initiator: ByStr20)
-IsProxy;
-IsAdmin initiator;
-reward_cycle_list := list;
-lastrewardcycle := last_cycle
 end
 transition DrainContractBalance(amt: Uint128, initiator: ByStr20)
 IsProxy;

--- a/tests/ssnlist.scilla
+++ b/tests/ssnlist.scilla
@@ -78,69 +78,54 @@ let uint128_10_power_7 = Uint128 10000000
 let uint128_100 = Uint128 100
 let addfunds_tag = "AddFunds"
 type Error =
-| ContractFreezedFailure
+| ContractFrozenFailure
 | VerifierValidationFailed
 | AdminValidationFailed
 | ProxyValidationFailed
 | DelegDoesNotExistAtSSN
-| DelegDepositBlowMin
 | DelegHasBufferedDeposit
 | ChangeCommError
 | SSNNotExist
-| DelegNotExist
 | SSNAlreadyExist
 | DelegHasUnwithdrawRewards
 | DelegHasNoSufficientAmt
 | SSNNoComm
 | DelegStakeNotEnough
-| GZILValidationFailed
 | ExceedMaxChangeRate
 | ExceedMaxCommRate
 | InvalidTotalAmt
 | InvalidRecvAddr
 | VerifierNotSet
-<<<<<<< HEAD
-| NotTimeYet
-| NoPendingWithdrawal
-| InvalidWithdrawAmt
-=======
->>>>>>> 5ea1b34... fix: clarify reward cycle
 | VerifierRecvAddrNotSet
 let make_error =
 fun (result: Error) =>
 let result_code =
 match result with
-| ContractFreezedFailure => Int32 -1
+| ContractFrozenFailure => Int32 -1
 | VerifierValidationFailed => Int32 -2
 | AdminValidationFailed => Int32 -3
 | ProxyValidationFailed => Int32 -4
 | DelegDoesNotExistAtSSN => Int32 -5
-| DelegDepositBlowMin => Int32 -6
-| DelegHasBufferedDeposit => Int32 -7
-| ChangeCommError => Int32 -8
-| SSNNotExist => Int32 -9
-| DelegNotExist => Int32 -10
-| SSNAlreadyExist => Int32 -11
-| DelegHasUnwithdrawRewards => Int32 -12
-| DelegHasNoSufficientAmt => Int32 -13
-| SSNNoComm => Int32 -14
-| DelegStakeNotEnough => Int32 -15
-| GZILValidationFailed => Int32 -16
-| ExceedMaxChangeRate => Int32 -17
-| ExceedMaxCommRate => Int32 -18
-| InvalidTotalAmt => Int32 -19
-| InvalidRecvAddr => Int32 -20
-| VerifierNotSet => Int32 -21
-| NotTimeYet => Int32 -22
-| NoPendingWithdrawal => Int32 -23
-| InvalidWithdrawAmt => Int32 -24
-| VerifierRecvAddrNotSet => Int32 -25
+| DelegHasBufferedDeposit => Int32 -6
+| ChangeCommError => Int32 -7
+| SSNNotExist => Int32 -8
+| SSNAlreadyExist => Int32 -9
+| DelegHasUnwithdrawRewards => Int32 -10
+| DelegHasNoSufficientAmt => Int32 -11
+| SSNNoComm => Int32 -12
+| DelegStakeNotEnough => Int32 -13
+| ExceedMaxChangeRate => Int32 -14
+| ExceedMaxCommRate => Int32 -15
+| InvalidTotalAmt => Int32 -16
+| InvalidRecvAddr => Int32 -17
+| VerifierNotSet => Int32 -18
+| VerifierRecvAddrNotSet => Int32 -19
 end
 in
 { _exception: "Error"; code: result_code }
 contract SSNList(
 init_admin: ByStr20,
-proxy_address: ByStr20,
+init_proxy_address: ByStr20,
 gzil_address: ByStr20
 )
 field ssnlist: Map ByStr20 Ssn = Emp ByStr20 Ssn
@@ -152,19 +137,19 @@ field direct_deposit_deleg: Map ByStr20 (Map ByStr20 (Map Uint128 Uint128)) = Em
 field last_withdraw_cycle_deleg: Map ByStr20 (Map ByStr20 Uint128) = Emp ByStr20 (Map ByStr20 Uint128)
 field last_buf_deposit_cycle_deleg: Map ByStr20 (Map ByStr20 Uint128) = Emp ByStr20 (Map ByStr20 Uint128)
 field stake_ssn_per_cycle: Map ByStr20 (Map Uint128 SSNCycleInfo) = Emp ByStr20 (Map Uint128 SSNCycleInfo)
+field deleg_stake_per_cycle: Map ByStr20 (Map ByStr20 (Map Uint128 Uint128)) = Emp ByStr20 (Map ByStr20 (Map Uint128 Uint128))
 field withdrawal_pending: Map ByStr20 (Map BNum Uint128) = Emp ByStr20 (Map BNum Uint128)
-field bnum_req: Uint128 = Uint128 10000
-field stake_deleg_per_cycle: Map Uint128 Uint128 = Emp Uint128 Uint128
+field bnum_req: Uint128 = Uint128 24000
 field rewards_amt_deleg: Map ByStr20 (Map ByStr20 Uint128) = Emp ByStr20 (Map ByStr20 Uint128)
 field avaiable_withdrawal: Uint128 = uint128_zero
 field current_deleg: Option ByStr20 = None {ByStr20}
 field reward_cycle_list: List Uint128   =  Nil {Uint128}
 field verifier: Option ByStr20 = None {ByStr20}
 field verifier_receiving_addr: Option ByStr20 = None {ByStr20}
-field minstake: Uint128 = Uint128 0
-field mindelegstake: Uint128 = Uint128 1000000000000
+field minstake: Uint128 = Uint128 10000000000000000000
+field mindelegstake: Uint128 = Uint128 1000000000000000
 field contractadmin: ByStr20  = init_admin
-field proxyaddr: ByStr20 = proxy_address
+field proxyaddr: ByStr20 = init_proxy_address
 field gziladdr: ByStr20 = gzil_address
 field lastrewardcycle: Uint128 = uint128_one
 field paused: Bool = True
@@ -246,7 +231,7 @@ e = VerifierValidationFailed;
 ThrowError e
 end
 | None =>
-e = VerifierValidationFailed;
+e = VerifierNotSet;
 ThrowError e
 end
 end
@@ -261,7 +246,8 @@ ThrowError e
 end
 end
 procedure IsProxy()
-is_proxy = builtin eq _sender proxy_address;
+proxy_tmp <- proxyaddr;
+is_proxy = builtin eq _sender proxy_tmp;
 match is_proxy with
 | True  =>
 | False =>
@@ -274,7 +260,7 @@ paused_tmp <- paused;
 match paused_tmp with
 | False =>
 | True  =>
-e = ContractFreezedFailure;
+e = ContractFrozenFailure;
 ThrowError e
 end
 end
@@ -430,12 +416,8 @@ TruncateDeleg deleg ssnaddr;
 deposit_amt_deleg[deleg][ssnaddr] := rest_deleg;
 ssn_deleg_amt[ssnaddr][deleg] := rest_deleg;
 direct_deposit_deleg[deleg][ssnaddr][lrc] := rest_deleg;
-<<<<<<< HEAD
 last_withdraw_cycle_deleg[deleg][ssnaddr] := lrc;
 last_buf_deposit_cycle_deleg[deleg][ssnaddr] := lrc
-=======
-last_withdraw_cycle_deleg[deleg][ssnaddr] := lrc
->>>>>>> 5ea1b34... fix: clarify reward cycle
 end
 | False =>
 e = DelegHasNoSufficientAmt;
@@ -486,13 +468,14 @@ last2_reward_cycle = sub_one_to_zero last_reward_cycle;
 cur_opt <- direct_deposit_deleg[deleg][ssn_operator][last_reward_cycle];
 buf_opt <- buff_deposit_deleg[deleg][ssn_operator][last2_reward_cycle];
 comb_opt = option_add cur_opt buf_opt;
-result_map_opt <- stake_deleg_per_cycle[last_reward_cycle];
-stake_opt = option_add comb_opt result_map_opt;
-match stake_opt with
+last_amt_o <- deleg_stake_per_cycle[deleg][ssn_operator][last_reward_cycle];
+last_amt = option_uint128_value last_amt_o;
+match comb_opt with
 | Some stake =>
-stake_deleg_per_cycle[reward_cycle] := stake
+total_stake = builtin add last_amt stake;
+deleg_stake_per_cycle[deleg][ssn_operator][reward_cycle] := total_stake
 | None =>
-stake_deleg_per_cycle[reward_cycle] := uint128_zero
+deleg_stake_per_cycle[deleg][ssn_operator][reward_cycle] := last_amt
 end
 end
 end
@@ -512,7 +495,7 @@ end
 procedure CalcRewardsDelegPerCycle(tmp_arg: TmpArg)
 match tmp_arg with
 | TmpArg deleg ssn_operator reward_cycle =>
-staking_per_cycle_for_deleg_opt <- stake_deleg_per_cycle[reward_cycle];
+staking_per_cycle_for_deleg_opt <- deleg_stake_per_cycle[deleg][ssn_operator][reward_cycle];
 staking_and_rewards_per_cycle_for_ssn_opt <- stake_ssn_per_cycle[ssn_operator][reward_cycle];
 match staking_per_cycle_for_deleg_opt with
 | Some staking_of_deleg =>
@@ -535,22 +518,28 @@ rcl <- reward_cycle_list;
 list_reverse_uint128 = @list_reverse Uint128;
 rcl_reverse = list_reverse_uint128 rcl;
 list_need_compute_rewards = list_filter_between last_withdraw_cycle lrc rcl;
+list_reverse_uint128 = @list_reverse Uint128;
+list_need_compute_rewards_reverse = list_reverse_uint128 list_need_compute_rewards;
 mapper = @list_map Uint128 TmpArg;
 f = fun (cycle: Uint128) => TmpArg deleg ssn_operator cycle;
 combined_args_list = mapper f list_need_compute_rewards;
-emp_map = Emp Uint128 Uint128;
-stake_deleg_per_cycle := emp_map;
-rcl_reverse_t = mapper f rcl_reverse;
-forall rcl_reverse_t CalcStakeDelegPerCycle;
+list_need_compute_rewards_t = mapper f list_need_compute_rewards_reverse;
+forall list_need_compute_rewards_t CalcStakeDelegPerCycle;
 rewards_amt_deleg[ssn_operator][deleg] := uint128_zero;
 forall combined_args_list CalcRewardsDelegPerCycle;
 reward <- rewards_amt_deleg[ssn_operator][deleg];
 reward = option_uint128_value reward;
 SendDelegRewards deleg reward;
 MintCall deleg reward;
-sdpc <- stake_deleg_per_cycle;
-sdpc_list = builtin to_list sdpc;
-e = { _eventname: "WithdrawalStakeRewards"; reward_list_need: list_need_compute_rewards; combined_args_list: combined_args_list; stake_deleg_per_cycle: sdpc_list };
+ssn_o <- ssnlist[ssn_operator];
+match ssn_o with
+| Some (Ssn active_status stake_amt total_rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr) =>
+rest_rewards = builtin sub total_rewards reward;
+ssn = Ssn active_status stake_amt rest_rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr;
+ssnlist[ssn_operator] := ssn
+| None =>
+end;
+e = { _eventname: "WithdrawalStakeRewards"; reward_list_need: list_need_compute_rewards; combined_args_list: combined_args_list };
 event e;
 last_withdraw_cycle_deleg[deleg][ssn_operator] := lrc
 end
@@ -570,7 +559,6 @@ match active_status with
 | True  =>
 last_buf_deposit_cycle_deleg[initiator][ssnaddr] := lrc;
 new_buff_amt  = builtin add amount buffdeposit;
-new_stake_amt = builtin add new_buff_amt stake_amt;
 ssn = Ssn bool_active stake_amt rewards name urlraw urlapi new_buff_amt comm comm_rewards rec_addr;
 ssnlist[ssnaddr] := ssn;
 stake_amt_for_deleg_option  <- buff_deposit_deleg[initiator][ssnaddr][lrc];
@@ -635,9 +623,7 @@ end
 transition ChangeBNumReq(input_bnum_req: Uint128, initiator: ByStr20)
 IsProxy;
 IsAdmin initiator;
-bnum_req := input_bnum_req;
-e = { _eventname: "ChangeBNumReqSuccess"; input_bnum_req: input_bnum_req};
-event e
+bnum_req := input_bnum_req
 end
 transition UpdateContractAddr(proxy_addr: ByStr20, gzil_addr: ByStr20, initiator: ByStr20)
 IsProxy;
@@ -676,7 +662,7 @@ match ssn_o with
 ssn = Ssn active_status staking_amt deleg_reward new_name new_urlraw new_urlapi buffdeposit comm comm_rewards rec_addr;
 ssnlist[ssnaddr] := ssn
 | None =>
-e = SSNAlreadyExist;
+e = SSNNotExist;
 ThrowError e
 end
 end
@@ -749,7 +735,7 @@ ThrowError e
 end
 end
 end
-transition UpdateReceivedAddr(new_addr: ByStr20, initiator: ByStr20)
+transition UpdateReceivingAddr(new_addr: ByStr20, initiator: ByStr20)
 IsPaused;
 IsProxy;
 curval <- ssnlist[initiator];

--- a/tests/ssnlist.scilla
+++ b/tests/ssnlist.scilla
@@ -200,6 +200,9 @@ current_amt <- totalstakeamount;
 valid = uint128_le amt current_amt;
 match valid with
 | True =>
+current_amt <- totalstakeamount;
+new_amt = builtin sub current_amt amt;
+totalstakeamount := new_amt
 | False =>
 e = InvalidTotalAmt;
 ThrowError e

--- a/tests/ssnlist.scilla
+++ b/tests/ssnlist.scilla
@@ -71,7 +71,7 @@ builtin sub old new
 end
 let iota : Uint32 -> Uint32 -> List Uint32 =
 fun (m : Uint32) => fun (n : Uint32) =>
-let m_lt_n = uint32_le m n in
+let m_lt_n = builtin lt m n in
 match m_lt_n with
 | True =>
 let delta = builtin sub n m in
@@ -536,12 +536,12 @@ procedure WithdrawalStakeRewards(deleg: ByStr20, ssn_operator: ByStr20)
 last_withdraw_cycle_deleg_m <- last_withdraw_cycle_deleg[deleg][ssn_operator];
 last_withdraw_cycle = option_uint32_value last_withdraw_cycle_deleg_m;
 lrc <- lastrewardcycle;
-list_need_compute_rewards = iota last_withdraw_cycle lrc;
-list_reverse_uint32 = @list_reverse Uint32;
-list_need_compute_rewards_reverse = list_reverse_uint32 list_need_compute_rewards;
+m = builtin add last_withdraw_cycle uint32_one;
+n = builtin add lrc uint32_one;
+list_need_compute_rewards = iota m n;
 mapper = @list_map Uint32 TmpArg;
 f = fun (cycle: Uint32) => TmpArg deleg ssn_operator cycle;
-list_need_compute_rewards_t = mapper f list_need_compute_rewards_reverse;
+list_need_compute_rewards_t = mapper f list_need_compute_rewards;
 forall list_need_compute_rewards_t CalcStakeDelegPerCycle;
 combined_args_list = mapper f list_need_compute_rewards;
 rewards_amt_deleg[ssn_operator][deleg] := uint128_zero;


### PR DESCRIPTION
This PR is to fix rewards calculation issue due to the confusing concept of reward cycle, so I make following assumes:

1. When verifier invokes  `AssignStakeReward`, we first increase `lastrewardcycle` to cycle N, then update rewards (and delegates) for those ssn operators at cycle N.

2. When we calculate stake delegate for a specific delegator on a particular ssn operator at cycle N, we are using formula:

`stake_delegate_of_cycle_N = stake_delegate_of_cycle_N-1 + direct_deposit_deleg[N-1] + buff_deposit_deleg[N-2]`

(procedure CalcStakeDelegPerCycle)
(https://github.com/Zilliqa/zil-stake-js/blob/master/src/calculator.ts#L58)

3. When we compute rewards for a specific delegator on a particular ssn operator at cycle N, we are using:

`rewards_of_cycle_N = stake_delegate_of_cycle_N * total_rewards_for_that_ssn_at_cycle_N / total_delegate_on_that_ssn_at_cycle_N`

(procedure CalcRewardsDelegPerCycle)
(https://github.com/Zilliqa/zil-stake-js/blob/master/src/calculator.ts#L99)


Further optimization:

Fully remove `reward_cycle_list`.


Other fix:

1. `procedure DecreaseTotalStakeAmt`
2. Remove `gzil` from `proxy`
3. Fix `ReDelegateStake`
