### PR TITLE
Remove all vestige proxy transitions related to gZIL contract.

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -319,13 +319,12 @@ The table below describes the roles and privileges that this contract defines:
 
 ## Immutable Parameters
 
-The table below lists the parameters that are defined at the contrat deployment time and hence cannot be changed later on.
+The table below lists the parameters that are defined at the contract deployment time and hence cannot be changed later on.
 
 | Name | Type | Description |
 |--|--|--|
 |`init_implementation`| `ByStr20` | The address of the `SSNList` contract. |
 |`init_admin`| `ByStr20` | The address of the admin. |
-|`init_gzil_contract`| `ByStr20` | The address of the gZILToken contract. |
 
 ## Mutable Fields
 
@@ -335,8 +334,6 @@ The table below presents the mutable fields of the contract and their initial va
 |--|--|--|--|
 |`implementation`| `ByStr20` | `init_implementation` | Address of the current implementation of the `SSNList` contract. |
 |`admin`| `ByStr20` | `init_owner` | Current `admin` of the contract. |
-|`gzil_contract`| `ByStr20` | `init_gzil_contract` | Current address of the gZIL contract. |
-
 
 ## Transitions
 
@@ -350,8 +347,6 @@ All the transitions in the contract can be categorized into two categories:
 |--|--|--|
 |`UpgradeTo`| `newImplementation : ByStr20` |  Change the current implementation address of the `SSNList` contract. <br> :warning: **Note:** Only the `admin` can invoke this transition|
 |`ChangeProxyAdmin`| `newAdmin : ByStr20` |  Change the current `admin` of the contract. <br> :warning: **Note:** Only the `admin` can invoke this transition.|
-|`UpgradeGZILContract`| `newAddress : ByStr20` |  Change the address of `gzil_contract`. <br> :warning: **Note:** Only the `admin` can invoke this transition.|
-|`ChangeMinter`| `new_minter : ByStr20` |  Change the address of minter in `gzil_contract` by calling `ChangeMinter`. <br> :warning: **Note:** Only the `admin` can invoke this transition.|
 
 ### Relay Transitions
 

--- a/contracts/gzil.scilla
+++ b/contracts/gzil.scilla
@@ -23,7 +23,7 @@ type Error =
 | CodeInsufficientAllowance
 | CodeNotOwner
 | CodeNotMinter
-| CodeNotProxy
+
 let make_error =
   fun (result: Error) =>
     let result_code = 
@@ -33,7 +33,6 @@ let make_error =
       | CodeInsufficientAllowance => Int32 -3
       | CodeNotOwner              => Int32 -4
       | CodeNotMinter             => Int32 -5
-      | CodeNotProxy              => Int32 -6
       end
     in
     { _exception: "Error"; code: result_code }

--- a/contracts/proxy.scilla
+++ b/contracts/proxy.scilla
@@ -95,6 +95,15 @@ transition UpdateVerifier(verif: ByStr20)
     send msgs
 end
 
+(* @dev: Set the verifier rewarding address of the contract. Used by admin only. *)
+(* @param addr: New verifier receiving address *)
+transition UpdateVerifierRewardAddr(addr: ByStr20)
+    current_impl <- implementation;
+    msg = {_tag: "UpdateVerifierRewardAddr"; _recipient: current_impl; _amount: zero; addr: addr; initiator: _sender};
+    msgs = one_msg msg;
+    send msgs
+end
+
 (* @dev: Set the minstake, maxstake and contract maxstake of contract. Used by admin only. *)
 (* @param min_stake: New min_stake value *)
 (* @param min_deleg_stake: New mindelegstake value *)
@@ -140,6 +149,16 @@ transition UpdateSSN(ssnaddr: ByStr20, new_name: String, new_urlraw: String, new
     send msgs
 end
 
+(* @dev: Remove a specific ssn from ssnlist. Used by Admin only. *)
+(* @param ssnaddr: Address of the ssn to be removed *)
+transition RemoveSSN(ssnaddr: ByStr20)
+    current_impl <- implementation;
+    msg = {_tag: "RemoveSSN"; _recipient: current_impl; _amount: zero; ssnaddr: ssnaddr; initiator: _sender};
+    msgs = one_msg msg;
+    send msgs
+end
+
+
 (***************************************************)
 (*             SSN operator transition             *)
 (***************************************************)
@@ -162,21 +181,14 @@ end
 
 (* @dev : To update the received address for a given SSN *)
 (* @param new_address: The new received address *)
-transition UpdateReceivedAddr(new_addr: ByStr20)
+transition UpdateReceivingAddr(new_addr: ByStr20)
     current_impl <- implementation;
-    msg = {_tag: "UpdateReceivedAddr"; _recipient: current_impl; _amount: zero; new_addr: new_addr; initiator: _sender};
+    msg = {_tag: "UpdateReceivingAddr"; _recipient: current_impl; _amount: zero; new_addr: new_addr; initiator: _sender};
     msgs = one_msg msg;
     send msgs
 end
 
-(* @dev: Set the verifier rewarding address of the contract. Used by admin only. *)
-(* @param addr: New verifier receiving address *)
-transition UpdateVerifierRewardAddr(addr: ByStr20)
-    current_impl <- implementation;
-    msg = {_tag: "UpdateVerifierRewardAddr"; _recipient: current_impl; _amount: zero; addr: addr; initiator: _sender};
-    msgs = one_msg msg;
-    send msgs
-end
+
 
 (***************************************************)
 (*                Delegator transition             *)
@@ -270,28 +282,28 @@ transition UpdateDeleg(ssnaddr: ByStr20, deleg: ByStr20, stake_amt: Uint128)
     send msgs
 end
 
-transition PopulateStakeSSNPerCycle(ssn_addr: ByStr20, cycle: Uint128, info: SSNCycleInfo)
+transition PopulateStakeSSNPerCycle(ssn_addr: ByStr20, cycle: Uint32, info: SSNCycleInfo)
     current_impl <- implementation;
     msg = {_tag: "PopulateStakeSSNPerCycle"; _recipient: current_impl; _amount: zero; ssn_addr: ssn_addr; cycle: cycle; info: info; initiator: _sender};
     msgs = one_msg msg;
     send msgs
 end
 
-transition PopulateLastWithdrawCycleForDeleg(deleg_address: ByStr20, ssn_addr: ByStr20, cycle: Uint128)
+transition PopulateLastWithdrawCycleForDeleg(deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint32)
     current_impl <- implementation;
-    msg = {_tag: "PopulateLastWithdrawCycleForDeleg"; _recipient: current_impl; _amount: zero; ssn_addr: ssn_addr; deleg_addr: deleg_address; cycle: cycle; initiator: _sender};
+    msg = {_tag: "PopulateLastWithdrawCycleForDeleg"; _recipient: current_impl; _amount: zero; ssn_addr: ssn_addr; deleg_addr: deleg_addr; cycle: cycle; initiator: _sender};
     msgs = one_msg msg;
     send msgs
 end
 
-transition PopulateBuffDeposit(deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint128, amt: Uint128)
+transition PopulateBuffDeposit(deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint32, amt: Uint128)
     current_impl <- implementation;
     msg = {_tag: "PopulateBuffDeposit"; _recipient: current_impl; _amount: zero; ssn_addr: ssn_addr; deleg_addr: deleg_addr; cycle: cycle; amt: amt; initiator: _sender};
     msgs = one_msg msg;
     send msgs
 end
 
-transition PopulateDirectDeposit(deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint128, amt: Uint128)
+transition PopulateDirectDeposit(deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint32, amt: Uint128)
     current_impl <- implementation;
     msg = {_tag: "PopulateDirectDeposit"; _recipient: current_impl; _amount: zero; ssn_addr: ssn_addr; deleg_addr: deleg_addr; cycle: cycle; amt: amt; initiator: _sender};
     msgs = one_msg msg;
@@ -308,16 +320,6 @@ end
 transition PopulateTotalStakeAmt(amt: Uint128)
     current_impl <- implementation;
     msg = {_tag: "PopulateTotalStakeAmt"; _recipient: current_impl; _amount: zero; amt: amt; initiator: _sender};
-    msgs = one_msg msg;
-    send msgs
-end
-
-
-(* @dev: Remove a specific ssn from ssnlist. Used by Admin only. *)
-(* @param ssnaddr: Address of the ssn to be removed *)
-transition RemoveSSN(ssnaddr: ByStr20)
-    current_impl <- implementation;
-    msg = {_tag: "RemoveSSN"; _recipient: current_impl; _amount: zero; ssnaddr: ssnaddr; initiator: _sender};
     msgs = one_msg msg;
     send msgs
 end

--- a/contracts/proxy.scilla
+++ b/contracts/proxy.scilla
@@ -1,12 +1,17 @@
 scilla_version 0
+
 library SSNListProxy
+
 let zero = Uint128 0
+
 let one_msg =
   fun (m: Message) =>
     let e = Nil {Message} in
     Cons {Message} m e
+
 type SsnRewardShare =
 | SsnRewardShare of ByStr20 Uint128
+
 type SSNCycleInfo =
 | SSNCycleInfo of Uint128 Uint128
 (***************************************************)
@@ -14,13 +19,11 @@ type SSNCycleInfo =
 (***************************************************)
 contract SSNListProxy(
   init_implementation: ByStr20,
-  init_gzil_contract: ByStr20,
   init_admin: ByStr20
 )
 
 (* Mutable fields *)
 field implementation: ByStr20 = init_implementation
-field gzil_contract: ByStr20 = init_gzil_contract
 field admin: ByStr20 = init_admin
 
 (***************************************************)
@@ -57,29 +60,6 @@ transition ChangeProxyAdmin(newAdmin: ByStr20)
       event e
     end
 end
-
-transition UpgradeGZILContract(newAddress: ByStr20)
-    currentAdmin <- admin;
-    isAdmin = builtin eq currentAdmin _sender;
-    match isAdmin with
-    | True =>
-      gzil_contract := newAddress;
-      e = {_eventname: "Gzil Upgraded"; gzil_address: newAddress};
-      event e
-    | False =>
-      e = {_eventname: "UpgradeGZILContract FailedNotAdmin"; gzil_address: newAddress};
-      event e
-    end
-end
-
-(* Transitions will be sent to gZIL implemetion *)
-transition ChangeMinter(new_minter: ByStr20)
-    gzil <- gzil_contract;
-    msg = {_tag: "ChangeMinter"; _recipient: gzil; _amount: zero; new_minter: new_minter; initiator: _sender};
-    msgs = one_msg msg;
-    send msgs
-end
-
 
 (***************************************************)
 (*            House keeping transition             *)


### PR DESCRIPTION
This PR removes the address of the gZIL contract as the immutable variable in the SSNListProxy contract. It also removes a few transitions that are vestigial.