### PR TITLE
audit 6.1

### DIFF
--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -391,6 +391,8 @@ procedure DecreaseTotalStakeAmtOnStatus(amt: Uint128, status: Bool)
   match status with
   | True =>
   | False =>
+    e = { _eventname: "SSN becomes inactive"; decreased_amt: amt };
+    event e;
     DecreaseTotalStakeAmt amt
   end
 end
@@ -519,7 +521,8 @@ procedure UpdateStakeReward(entry: SsnStakeRewardShare)
         deleg_reward = builtin add delegate_reward rewards;
         ssn = Ssn active_status new_stake_amt deleg_reward name urlraw urlapi uint128_zero comm total_reward_comm rec_addr;
         ssnlist[ssnaddr] := ssn;
-        IncreaseTotalStakeAmtOnStatus buffdeposit active_status;
+        (* SSN is active, increase totakstakeamt with buffdeposit *)
+        IncreaseTotalStakeAmt buffdeposit;
         e = { _eventname: "SSN assign reward"; ssn_addr: ssnaddr; total_reward: total_reward_comm };
         event e
       end
@@ -656,16 +659,25 @@ procedure ReDelegStakeAmt(initiator: ByStr20, ssn: ByStr20, redeleg_amt: Uint128
       HasBufferedDeposit ssn initiator;
       AdjustDeleg ssn initiator amt redeleg_amt;
       (* Illegal withdraw amount could be handled in procedure AdjustDeleg *)
-      DecreaseTotalStakeAmt redeleg_amt;
       new_amt = builtin sub stake_amt redeleg_amt;
       minstake_tmp <- minstake;
       status = uint128_le minstake_tmp new_amt;
       ssn_option_tmp = Ssn status new_amt rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr;
       ssnlist[ssn] := ssn_option_tmp;
-      (* If ssn becomes inactive, we need to decrease the rest ones also *)
-      DecreaseTotalStakeAmtOnStatus new_amt status;
       e = { _eventname: "Remove delegate from SSN"; ssn_addr: ssn; deleg_address: initiator; amt: redeleg_amt };
-      event e
+      event e;
+      match active_status with
+      | True =>
+        (* If the original status is active, we can substract from totalstakeamt, otherwise dont do so *)
+        DecreaseTotalStakeAmt redeleg_amt;
+        event_decrease = { _eventname: "SSN was active, decrease it"; decreased_amt: redeleg_amt };
+        event event_decrease;
+        (* If ssn becomes inactive, we need to decrease the rest ones as well *)
+        DecreaseTotalStakeAmtOnStatus new_amt status
+      | False =>
+        event_decrease = { _eventname: "SSN was inactive, wont effect totalstakeamt" };
+        event event_decrease
+      end
     | None =>
       e = DelegDoesNotExistAtSSN;
       ThrowError e
@@ -688,14 +700,11 @@ procedure WithdrawalStakeAmt(initiator: ByStr20, ssn: ByStr20, withdraw_amount: 
       HasBufferedDeposit ssn initiator;
       AdjustDeleg ssn initiator amt withdraw_amount;
       (* Illegal withdraw amount could be handled in procedure AdjustDeleg *)
-      DecreaseTotalStakeAmt withdraw_amount;
       new_amt = builtin sub stake_amt withdraw_amount;
       minstake_tmp <- minstake;
       status = uint128_le minstake_tmp new_amt;
       ssn_option_tmp = Ssn status new_amt rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr;
       ssnlist[ssn] := ssn_option_tmp;
-      (* If ssn becomes inactive, we need to decrease the rest ones also *)
-      DecreaseTotalStakeAmtOnStatus new_amt status;
       withdrawal_bnum <- & BLOCKNUMBER;
       withdraw_amt_o <- withdrawal_pending[initiator][withdrawal_bnum];
       withdraw_amt_pending = match withdraw_amt_o with
@@ -704,7 +713,19 @@ procedure WithdrawalStakeAmt(initiator: ByStr20, ssn: ByStr20, withdraw_amount: 
       end;
       withdrawal_pending[initiator][withdrawal_bnum] := withdraw_amt_pending;
       e = { _eventname: "Deleg withdraw deposit"; ssn_addr: ssn; deleg_address: initiator; amt: amt };
-      event e
+      event e;
+      match active_status with
+      | True =>
+        (* If the original status is active, we can substract from totalstakeamt, otherwise dont do so *)
+        DecreaseTotalStakeAmt withdraw_amount;
+        event_decrease = { _eventname: "SSN was active, decrease it"; decreased_amt: redeleg_amt };
+        event event_decrease;
+        (* If ssn becomes inactive, we need to decrease the rest as well *)
+        DecreaseTotalStakeAmtOnStatus new_amt status;
+      | False =>
+        event_decrease = { _eventname: "SSN was inactive, wont effect totalstakeamt" };
+        event event_decrease
+      end
     | None =>
       e = DelegDoesNotExistAtSSN;
       ThrowError e

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -521,8 +521,7 @@ procedure UpdateStakeReward(entry: SsnStakeRewardShare)
         deleg_reward = builtin add delegate_reward rewards;
         ssn = Ssn active_status new_stake_amt deleg_reward name urlraw urlapi uint128_zero comm total_reward_comm rec_addr;
         ssnlist[ssnaddr] := ssn;
-        (* SSN is active, increase totakstakeamt with buffdeposit *)
-        IncreaseTotalStakeAmt buffdeposit;
+        IncreaseTotalStakeAmtOnStatus buffdeposit active_status;
         e = { _eventname: "SSN assign reward"; ssn_addr: ssnaddr; total_reward: total_reward_comm };
         event e
       end
@@ -659,25 +658,16 @@ procedure ReDelegStakeAmt(initiator: ByStr20, ssn: ByStr20, redeleg_amt: Uint128
       HasBufferedDeposit ssn initiator;
       AdjustDeleg ssn initiator amt redeleg_amt;
       (* Illegal withdraw amount could be handled in procedure AdjustDeleg *)
+      DecreaseTotalStakeAmt redeleg_amt;
       new_amt = builtin sub stake_amt redeleg_amt;
       minstake_tmp <- minstake;
       status = uint128_le minstake_tmp new_amt;
       ssn_option_tmp = Ssn status new_amt rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr;
       ssnlist[ssn] := ssn_option_tmp;
+      (* If ssn becomes inactive, we need to decrease the rest ones also *)
+      DecreaseTotalStakeAmtOnStatus new_amt status;
       e = { _eventname: "Remove delegate from SSN"; ssn_addr: ssn; deleg_address: initiator; amt: redeleg_amt };
-      event e;
-      match active_status with
-      | True =>
-        (* If the original status is active, we can substract from totalstakeamt, otherwise dont do so *)
-        DecreaseTotalStakeAmt redeleg_amt;
-        event_decrease = { _eventname: "SSN was active, decrease it"; decreased_amt: redeleg_amt };
-        event event_decrease;
-        (* If ssn becomes inactive, we need to decrease the rest ones as well *)
-        DecreaseTotalStakeAmtOnStatus new_amt status
-      | False =>
-        event_decrease = { _eventname: "SSN was inactive, wont effect totalstakeamt" };
-        event event_decrease
-      end
+      event e
     | None =>
       e = DelegDoesNotExistAtSSN;
       ThrowError e
@@ -700,11 +690,14 @@ procedure WithdrawalStakeAmt(initiator: ByStr20, ssn: ByStr20, withdraw_amount: 
       HasBufferedDeposit ssn initiator;
       AdjustDeleg ssn initiator amt withdraw_amount;
       (* Illegal withdraw amount could be handled in procedure AdjustDeleg *)
+      DecreaseTotalStakeAmt withdraw_amount;
       new_amt = builtin sub stake_amt withdraw_amount;
       minstake_tmp <- minstake;
       status = uint128_le minstake_tmp new_amt;
       ssn_option_tmp = Ssn status new_amt rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr;
       ssnlist[ssn] := ssn_option_tmp;
+      (* If ssn becomes inactive, we need to decrease the rest ones also *)
+      DecreaseTotalStakeAmtOnStatus new_amt status;
       withdrawal_bnum <- & BLOCKNUMBER;
       withdraw_amt_o <- withdrawal_pending[initiator][withdrawal_bnum];
       withdraw_amt_pending = match withdraw_amt_o with
@@ -713,19 +706,7 @@ procedure WithdrawalStakeAmt(initiator: ByStr20, ssn: ByStr20, withdraw_amount: 
       end;
       withdrawal_pending[initiator][withdrawal_bnum] := withdraw_amt_pending;
       e = { _eventname: "Deleg withdraw deposit"; ssn_addr: ssn; deleg_address: initiator; amt: amt };
-      event e;
-      match active_status with
-      | True =>
-        (* If the original status is active, we can substract from totalstakeamt, otherwise dont do so *)
-        DecreaseTotalStakeAmt withdraw_amount;
-        event_decrease = { _eventname: "SSN was active, decrease it"; decreased_amt: withdraw_amount };
-        event event_decrease;
-        (* If ssn becomes inactive, we need to decrease the rest as well *)
-        DecreaseTotalStakeAmtOnStatus new_amt status
-      | False =>
-        event_decrease = { _eventname: "SSN was inactive, wont effect totalstakeamt" };
-        event event_decrease
-      end
+      event e
     | None =>
       e = DelegDoesNotExistAtSSN;
       ThrowError e

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -718,10 +718,10 @@ procedure WithdrawalStakeAmt(initiator: ByStr20, ssn: ByStr20, withdraw_amount: 
       | True =>
         (* If the original status is active, we can substract from totalstakeamt, otherwise dont do so *)
         DecreaseTotalStakeAmt withdraw_amount;
-        event_decrease = { _eventname: "SSN was active, decrease it"; decreased_amt: redeleg_amt };
+        event_decrease = { _eventname: "SSN was active, decrease it"; decreased_amt: withdraw_amount };
         event event_decrease;
         (* If ssn becomes inactive, we need to decrease the rest as well *)
-        DecreaseTotalStakeAmtOnStatus new_amt status;
+        DecreaseTotalStakeAmtOnStatus new_amt status
       | False =>
         event_decrease = { _eventname: "SSN was inactive, wont effect totalstakeamt" };
         event event_decrease

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -49,6 +49,15 @@ type Ssn =
 type SsnRewardShare =
 | SsnRewardShare of ByStr20 Uint128
 
+(*  SSNAddress        : ByStr20 *)
+(*                      Address of the SSN. *)
+(*  CycleReward       : Uint128 *)
+(*                      Integer representation of reward assigned by the verifier to this SSN for this cycle. *)
+(*  TotalStakeAmount  : Uint128 *)
+(*                      Total stake amount at a specific cycle.                                               *)
+type SsnStakeRewardShare = 
+| SsnStakeRewardShare of ByStr20 Uint128 Uint128
+
 (* SSNCycleInfo Data Type *)
 
 (*   Each SSNCycleInfo has the following fields: *)
@@ -158,6 +167,13 @@ let iota : Uint32 -> Uint32 -> List Uint32 =
         | Pair xs m => xs
         end
     | False => Nil {Uint32}
+    end
+
+let map_to_stake_rewards = 
+  fun (total_stake: Uint128) =>
+  fun (element: SsnRewardShare) =>
+    match element with
+    | SsnRewardShare ssnaddr cycle_reward => SsnStakeRewardShare ssnaddr cycle_reward total_stake 
     end
 
 let bool_active = True
@@ -462,10 +478,10 @@ procedure CalculateTotalWithdrawal(withdraw: Pair BNum Uint128)
 end
 
 
-procedure UpdateStakeReward(entry: SsnRewardShare)
+procedure UpdateStakeReward(entry: SsnStakeRewardShare)
   lastreward_blk <- lastrewardcycle;
   match entry with
-  | SsnRewardShare ssnaddr cycle_reward =>
+  | SsnStakeRewardShare ssnaddr cycle_reward total_stake =>
     curval <- ssnlist[ssnaddr];
     match curval with
     | None =>
@@ -478,9 +494,8 @@ procedure UpdateStakeReward(entry: SsnRewardShare)
         event e
       | True  =>
         (* To calculate rewards belong to this ssn operator *)
-        total_stake_amt <- totalstakeamount;
         new_rewards_tmp = builtin mul stake_amt cycle_reward;
-        new_rewards = builtin div new_rewards_tmp total_stake_amt;
+        new_rewards = builtin div new_rewards_tmp total_stake;
 
         (* Substract from verifier_reward, scilla would help us with underflow exception which should not happen *)
         current_verifier_reward <- verifier_reward;
@@ -1159,7 +1174,13 @@ transition AssignStakeReward(ssnreward_list: List SsnRewardShare, available_rewa
   newLastRewardCycleNum = builtin add uint32_one lrc;
   lastrewardcycle := newLastRewardCycleNum;
   verifier_reward := available_reward;
-  forall ssnreward_list UpdateStakeReward;
+  
+  total_stake_amt <- totalstakeamount;
+  f = map_to_stake_rewards total_stake_amt;
+
+  mapper = @list_map SsnRewardShare SsnStakeRewardShare;
+  ssn_stake_reward_list = mapper f ssnreward_list;
+  forall ssn_stake_reward_list UpdateStakeReward;
   verifier_reward_amt <- verifier_reward;
   verifier_o <- verifier_receiving_addr;
   match verifier_o with

--- a/tests/ssnlist.scilla
+++ b/tests/ssnlist.scilla
@@ -353,7 +353,7 @@ new_stake_amt = builtin add stake_amt buffdeposit;
 deleg_reward = builtin add delegate_reward rewards;
 ssn = Ssn active_status new_stake_amt deleg_reward name urlraw urlapi uint128_zero comm total_reward_comm rec_addr;
 ssnlist[ssnaddr] := ssn;
-IncreaseTotalStakeAmt buffdeposit;
+IncreaseTotalStakeAmtOnStatus buffdeposit active_status;
 e = { _eventname: "SSN assign reward"; ssn_addr: ssnaddr; total_reward: total_reward_comm };
 event e
 end
@@ -473,23 +473,15 @@ match deleg with
 HasRewardToWithdraw ssn initiator rewards;
 HasBufferedDeposit ssn initiator;
 AdjustDeleg ssn initiator amt redeleg_amt;
+DecreaseTotalStakeAmt redeleg_amt;
 new_amt = builtin sub stake_amt redeleg_amt;
 minstake_tmp <- minstake;
 status = uint128_le minstake_tmp new_amt;
 ssn_option_tmp = Ssn status new_amt rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr;
 ssnlist[ssn] := ssn_option_tmp;
+DecreaseTotalStakeAmtOnStatus new_amt status;
 e = { _eventname: "Remove delegate from SSN"; ssn_addr: ssn; deleg_address: initiator; amt: redeleg_amt };
-event e;
-match active_status with
-| True =>
-DecreaseTotalStakeAmt redeleg_amt;
-event_decrease = { _eventname: "SSN was active, decrease it"; decreased_amt: redeleg_amt };
-event event_decrease;
-DecreaseTotalStakeAmtOnStatus new_amt status
-| False =>
-event_decrease = { _eventname: "SSN was inactive, wont effect totalstakeamt" };
-event event_decrease
-end
+event e
 | None =>
 e = DelegDoesNotExistAtSSN;
 ThrowError e
@@ -510,11 +502,13 @@ match deleg with
 HasRewardToWithdraw ssn initiator rewards;
 HasBufferedDeposit ssn initiator;
 AdjustDeleg ssn initiator amt withdraw_amount;
+DecreaseTotalStakeAmt withdraw_amount;
 new_amt = builtin sub stake_amt withdraw_amount;
 minstake_tmp <- minstake;
 status = uint128_le minstake_tmp new_amt;
 ssn_option_tmp = Ssn status new_amt rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr;
 ssnlist[ssn] := ssn_option_tmp;
+DecreaseTotalStakeAmtOnStatus new_amt status;
 withdrawal_bnum <- & BLOCKNUMBER;
 withdraw_amt_o <- withdrawal_pending[initiator][withdrawal_bnum];
 withdraw_amt_pending = match withdraw_amt_o with
@@ -523,17 +517,7 @@ withdraw_amt_pending = match withdraw_amt_o with
 end;
 withdrawal_pending[initiator][withdrawal_bnum] := withdraw_amt_pending;
 e = { _eventname: "Deleg withdraw deposit"; ssn_addr: ssn; deleg_address: initiator; amt: amt };
-event e;
-match active_status with
-| True =>
-DecreaseTotalStakeAmt withdraw_amount;
-event_decrease = { _eventname: "SSN was active, decrease it"; decreased_amt: withdraw_amount };
-event event_decrease;
-DecreaseTotalStakeAmtOnStatus new_amt status
-| False =>
-event_decrease = { _eventname: "SSN was inactive, wont effect totalstakeamt" };
-event event_decrease
-end
+event e
 | None =>
 e = DelegDoesNotExistAtSSN;
 ThrowError e

--- a/tests/ssnlist.scilla
+++ b/tests/ssnlist.scilla
@@ -5,6 +5,8 @@ type Ssn =
 | Ssn of Bool Uint128 Uint128 String String String Uint128 Uint128 Uint128 ByStr20
 type SsnRewardShare =
 | SsnRewardShare of ByStr20 Uint128
+type SsnStakeRewardShare =
+| SsnStakeRewardShare of ByStr20 Uint128 Uint128
 type SSNCycleInfo =
 | SSNCycleInfo of Uint128 Uint128
 type TmpArg =
@@ -91,6 +93,12 @@ match xs_m with
 | Pair xs m => xs
 end
 | False => Nil {Uint32}
+end
+let map_to_stake_rewards =
+fun (total_stake: Uint128) =>
+fun (element: SsnRewardShare) =>
+match element with
+| SsnRewardShare ssnaddr cycle_reward => SsnStakeRewardShare ssnaddr cycle_reward total_stake
 end
 let bool_active = True
 let bool_inactive = False
@@ -312,10 +320,10 @@ end
 | None =>
 end
 end
-procedure UpdateStakeReward(entry: SsnRewardShare)
+procedure UpdateStakeReward(entry: SsnStakeRewardShare)
 lastreward_blk <- lastrewardcycle;
 match entry with
-| SsnRewardShare ssnaddr cycle_reward =>
+| SsnStakeRewardShare ssnaddr cycle_reward total_stake =>
 curval <- ssnlist[ssnaddr];
 match curval with
 | None =>
@@ -327,9 +335,8 @@ match active_status with
 e = { _eventname: "SSN inactive"; ssn_addr: ssnaddr};
 event e
 | True  =>
-total_stake_amt <- totalstakeamount;
 new_rewards_tmp = builtin mul stake_amt cycle_reward;
-new_rewards = builtin div new_rewards_tmp total_stake_amt;
+new_rewards = builtin div new_rewards_tmp total_stake;
 current_verifier_reward <- verifier_reward;
 new_current_verifier_reward = builtin sub current_verifier_reward new_rewards;
 verifier_reward := new_current_verifier_reward;
@@ -862,7 +869,11 @@ lrc <- lastrewardcycle;
 newLastRewardCycleNum = builtin add uint32_one lrc;
 lastrewardcycle := newLastRewardCycleNum;
 verifier_reward := available_reward;
-forall ssnreward_list UpdateStakeReward;
+total_stake_amt <- totalstakeamount;
+f = map_to_stake_rewards total_stake_amt;
+mapper = @list_map SsnRewardShare SsnStakeRewardShare;
+ssn_stake_reward_list = mapper f ssnreward_list;
+forall ssn_stake_reward_list UpdateStakeReward;
 verifier_reward_amt <- verifier_reward;
 verifier_o <- verifier_receiving_addr;
 match verifier_o with

--- a/tests/ssnlist.scilla
+++ b/tests/ssnlist.scilla
@@ -527,9 +527,9 @@ event e;
 match active_status with
 | True =>
 DecreaseTotalStakeAmt withdraw_amount;
-event_decrease = { _eventname: "SSN was active, decrease it"; decreased_amt: redeleg_amt };
+event_decrease = { _eventname: "SSN was active, decrease it"; decreased_amt: withdraw_amount };
 event event_decrease;
-DecreaseTotalStakeAmtOnStatus new_amt status;
+DecreaseTotalStakeAmtOnStatus new_amt status
 | False =>
 event_decrease = { _eventname: "SSN was inactive, wont effect totalstakeamt" };
 event event_decrease

--- a/tests/ssnlist.scilla
+++ b/tests/ssnlist.scilla
@@ -246,6 +246,8 @@ procedure DecreaseTotalStakeAmtOnStatus(amt: Uint128, status: Bool)
 match status with
 | True =>
 | False =>
+e = { _eventname: "SSN becomes inactive"; decreased_amt: amt };
+event e;
 DecreaseTotalStakeAmt amt
 end
 end
@@ -351,7 +353,7 @@ new_stake_amt = builtin add stake_amt buffdeposit;
 deleg_reward = builtin add delegate_reward rewards;
 ssn = Ssn active_status new_stake_amt deleg_reward name urlraw urlapi uint128_zero comm total_reward_comm rec_addr;
 ssnlist[ssnaddr] := ssn;
-IncreaseTotalStakeAmtOnStatus buffdeposit active_status;
+IncreaseTotalStakeAmt buffdeposit;
 e = { _eventname: "SSN assign reward"; ssn_addr: ssnaddr; total_reward: total_reward_comm };
 event e
 end
@@ -471,15 +473,23 @@ match deleg with
 HasRewardToWithdraw ssn initiator rewards;
 HasBufferedDeposit ssn initiator;
 AdjustDeleg ssn initiator amt redeleg_amt;
-DecreaseTotalStakeAmt redeleg_amt;
 new_amt = builtin sub stake_amt redeleg_amt;
 minstake_tmp <- minstake;
 status = uint128_le minstake_tmp new_amt;
 ssn_option_tmp = Ssn status new_amt rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr;
 ssnlist[ssn] := ssn_option_tmp;
-DecreaseTotalStakeAmtOnStatus new_amt status;
 e = { _eventname: "Remove delegate from SSN"; ssn_addr: ssn; deleg_address: initiator; amt: redeleg_amt };
-event e
+event e;
+match active_status with
+| True =>
+DecreaseTotalStakeAmt redeleg_amt;
+event_decrease = { _eventname: "SSN was active, decrease it"; decreased_amt: redeleg_amt };
+event event_decrease;
+DecreaseTotalStakeAmtOnStatus new_amt status
+| False =>
+event_decrease = { _eventname: "SSN was inactive, wont effect totalstakeamt" };
+event event_decrease
+end
 | None =>
 e = DelegDoesNotExistAtSSN;
 ThrowError e
@@ -500,13 +510,11 @@ match deleg with
 HasRewardToWithdraw ssn initiator rewards;
 HasBufferedDeposit ssn initiator;
 AdjustDeleg ssn initiator amt withdraw_amount;
-DecreaseTotalStakeAmt withdraw_amount;
 new_amt = builtin sub stake_amt withdraw_amount;
 minstake_tmp <- minstake;
 status = uint128_le minstake_tmp new_amt;
 ssn_option_tmp = Ssn status new_amt rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr;
 ssnlist[ssn] := ssn_option_tmp;
-DecreaseTotalStakeAmtOnStatus new_amt status;
 withdrawal_bnum <- & BLOCKNUMBER;
 withdraw_amt_o <- withdrawal_pending[initiator][withdrawal_bnum];
 withdraw_amt_pending = match withdraw_amt_o with
@@ -515,7 +523,17 @@ withdraw_amt_pending = match withdraw_amt_o with
 end;
 withdrawal_pending[initiator][withdrawal_bnum] := withdraw_amt_pending;
 e = { _eventname: "Deleg withdraw deposit"; ssn_addr: ssn; deleg_address: initiator; amt: amt };
-event e
+event e;
+match active_status with
+| True =>
+DecreaseTotalStakeAmt withdraw_amount;
+event_decrease = { _eventname: "SSN was active, decrease it"; decreased_amt: redeleg_amt };
+event event_decrease;
+DecreaseTotalStakeAmtOnStatus new_amt status;
+| False =>
+event_decrease = { _eventname: "SSN was inactive, wont effect totalstakeamt" };
+event event_decrease
+end
 | None =>
 e = DelegDoesNotExistAtSSN;
 ThrowError e


### PR DESCRIPTION
Fixes #127 
1. Define a new type `SsnStakeRewardShare`:
```
(*  SSNAddress        : ByStr20 *)
(*                      Address of the SSN. *)
(*  CycleReward       : Uint128 *)
(*                      Integer representation of reward assigned by the verifier to this SSN for this cycle. *)
(*  TotalStakeAmount  : Uint128 *)
(*                      Total stake amount at a specific cycle.                                               *)
type SsnStakeRewardShare = 
| SsnStakeRewardShare of ByStr20 Uint128 Uint128
```

2. Convert `List SsnRewardShare` to `List SsnStakeRewardShare` in transition `AssignStakeReward`

So now we are using a consistent stake_total_amount to compute rewards which can eliminate the bug.


Also see this issue #168 