### PR TITLE
audit 6.6,6.8,6.10,6.11,6.12

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -501,29 +501,29 @@ The first transition is meant to submit request for transfer of native ZILs whil
 | Name | Params | Description |
 |--|--|--|
 |`SubmitNativeTransaction`| `recipient : ByStr20, amount : Uint128, tag : String` | Submit a request for transfer of native tokens for future signoffs. |
-|`SubmitCustomUpgradeToTransaction`| `proxyContract : ByStr20, newImplementation : ByStr20` | Submit a request to invoke the `UpgradeTo` transition in the `SSNListProxy` contract. |
-|`SubmitCustomChangeProxyAdminTransaction`| `proxyContract : ByStr20, newAdmin : ByStr20` | Submit a request to invoke the `ChangeProxyAdmin` transition in the `SSNListProxy` contract. |
-|`SubmitCustomChangeMinterTransaction`| `proxyContract : ByStr20, new_minter : ByStr20` | Submit a request to invoke the `ChangeMinter` transition in the `gZILToken` contract. |
-|`SubmitCustomPauseTransaction`| `proxyContract : ByStr20` | Submit a request to invoke the `Pause` transition in the `SSNListProxy` contract. |
-|`SubmitCustomUnpauseTransaction`| `proxyContract : ByStr20` | Submit a request to invoke the `UnPause` transition in the `SSNListProxy` contract. |
-|`SubmitCustomUpdateAdminTransaction`| `proxyContract : ByStr20, admin : ByStr20` | Submit a request to invoke the `UpdateAdmin` transition in the `SSNListProxy` contract. |
-|`SubmitCustomUpdateVerifierTransaction`| `proxyContract : ByStr20, verif : ByStr20` | Submit a request to invoke the `UpdateVerifier` transition in the `SSNListProxy` contract. |
-|`SubmitCustomUpdateStakingParametersTransaction`| `proxyContract : ByStr20, min_stake : Uint128, min_deleg_stake : Uint128, max_comm_change_rate : Uint128` | Submit a request to invoke the `UpdateStakingParameters` transition in the `SSNListProxy` contract. |
-|`SubmitCustomChangeBNumReqTransaction`| `proxyContract : ByStr20, input_bnum_req : Uint128` | Submit a request to invoke the `ChangeBNumReq` transition in the `SSNListProxy` contract. |
-|`SubmitCustomUpdateGzilAddrTransaction`| `proxyContract : ByStr20, gzil_addr: ByStr20` | Submit a request to invoke the `UpdateGzilAddr` transition in the `SSNListProxy` contract. |
-|`SubmitCustomAddSSNTransaction`| `proxyContract : ByStr20, ssnaddr : ByStr20, stake_amount : Uint128, rewards : Uint128, urlraw : String, urlapi : String, buffered_deposit : Uint128` | Submit a request to invoke the `AddSSN` transition in the `SSNListProxy` contract. |
-|`SubmitCustomUpdateSSNTransaction`| `proxyContract : ByStr20, ssnaddr : ByStr20, new_name : String, new_urlraw : String, new_urlapi : String` | Submit a request to invoke the `UpdateSSN` transition in the `SSNListProxy` contract. |
-|`SubmitCustomAddSSNAfterUpgradeTransaction` | `proxyContract: ByStr20, ssnaddr: ByStr20, stake_amt: Uint128, rewards: Uint128, name: String, urlraw: String, urlapi: String, buff_deposit: Uint128, comm: Uint128, comm_rewards: Uint128, rec_addr: ByStr20` | Submit a request to invoke the `AddSSNAfterUpgrade` transition in the `SSNListProxy` contract. |
-|`SubmitUpdateDelegTransaction` | `proxyContract: ByStr20, ssnaddr: ByStr20, deleg: ByStr20, stake_amt: Uint128` | Submit a request to invoke the `UpdateDeleg` transition in the `SSNListProxy` contract. |
-|`SubmitPopulateStakeSSNPerCycleTransaction`| `proxyContract : ByStr20, ssn_address : ByStr20, cycle : Uint32, info : SSNCycleInfo` | Submit a request to invoke the `PopulateStakeSSNPerCycle` transition in the `SSNListProxy` contract. |
-|`SubmitPopulateLastWithdrawCycleFordelegTransaction`| `proxyContract : ByStr20, deleg_address : ByStr20, ssn_address : ByStr20, cycle : Uint32` | Submit a request to invoke the `PopulateLastWithdrawCycleFordeleg` transition in the `SSNListProxy` contract. |
-|`SubmitPopulateBufferedDepositTransaction`| `proxyContract : ByStr20, deleg_address : ByStr20, ssn_address : ByStr20, cycle : Uint32, amount : Uint128` | Submit a request to invoke the `PopulateBufferedDeposit` transition in the `SSNListProxy` contract. |
-|`SubmitPopulateDirectDepositTransaction`| `proxyContract : ByStr20, deleg_address : ByStr20, ssn_address : ByStr20, cycle : Uint32, amount : Uint128` | Submit a request to invoke the `PopulateDirectDeposit` transition in the `SSNListProxy` contract. |
-|`SubmitPopulateCommForSSNTransaction`| `proxyContract : ByStr20, ssn_address : ByStr20, cycle : Uint32, comm : Uint128` | Submit a request to invoke the `PopulateCommForSSN` transition in the `SSNListProxy` contract. |
-|`SubmitPopulateTotalStakeAmtTransaction`| `proxyContract : ByStr20, amt : Uint128` | Submit a request to invoke the `PopulateTotalStakeAmt` transition in the `SSNListProxy` contract. |
-|`SubmitCustomRemoveSSNTransaction`| `proxyContract : ByStr20, ssnaddr : ByStr20` | Submit a request to invoke the `RemoveSSN` transition in the `SSNListProxy` contract. |
-|`SubmitPopulateDepositAmountFordelegTransaction`| `proxyContract : ByStr20, deleg_address : ByStr20, ssn_address : ByStr20, amount : Uint128` | Submit a request to invoke the `PopulateDepositAmountFordeleg` transition in the `SSNListProxy` contract. |
-|`SubmitCustomDrainContractBalanceTransaction`| `proxyContract : ByStr20, amt : Uint128` | Submit a request to invoke the `DrainContractBalance` transition in the `SSNListProxy` contract. |
+|`SubmitCustomUpgradeToTransaction`| `calleeContract : ByStr20, newImplementation : ByStr20` | Submit a request to invoke the `UpgradeTo` transition in the `SSNListProxy` contract. |
+|`SubmitCustomChangeProxyAdminTransaction`| `calleeContract : ByStr20, newAdmin : ByStr20` | Submit a request to invoke the `ChangeProxyAdmin` transition in the `SSNListProxy` contract. |
+|`SubmitCustomChangeMinterTransaction`| `calleeContract : ByStr20, new_minter : ByStr20` | Submit a request to invoke the `ChangeMinter` transition in the `gZILToken` contract. |
+|`SubmitCustomPauseTransaction`| `calleeContract : ByStr20` | Submit a request to invoke the `Pause` transition in the `SSNListProxy` contract. |
+|`SubmitCustomUnpauseTransaction`| `calleeContract : ByStr20` | Submit a request to invoke the `UnPause` transition in the `SSNListProxy` contract. |
+|`SubmitCustomUpdateAdminTransaction`| `calleeContract : ByStr20, admin : ByStr20` | Submit a request to invoke the `UpdateAdmin` transition in the `SSNListProxy` contract. |
+|`SubmitCustomUpdateVerifierTransaction`| `calleeContract : ByStr20, verif : ByStr20` | Submit a request to invoke the `UpdateVerifier` transition in the `SSNListProxy` contract. |
+|`SubmitCustomUpdateStakingParametersTransaction`| `calleeContract : ByStr20, min_stake : Uint128, min_deleg_stake : Uint128, max_comm_change_rate : Uint128` | Submit a request to invoke the `UpdateStakingParameters` transition in the `SSNListProxy` contract. |
+|`SubmitCustomChangeBNumReqTransaction`| `calleeContract : ByStr20, input_bnum_req : Uint128` | Submit a request to invoke the `ChangeBNumReq` transition in the `SSNListProxy` contract. |
+|`SubmitCustomUpdateGzilAddrTransaction`| `calleeContract : ByStr20, gzil_addr: ByStr20` | Submit a request to invoke the `UpdateGzilAddr` transition in the `SSNListProxy` contract. |
+|`SubmitCustomAddSSNTransaction`| `calleeContract : ByStr20, ssnaddr : ByStr20, stake_amount : Uint128, rewards : Uint128, urlraw : String, urlapi : String, buffered_deposit : Uint128` | Submit a request to invoke the `AddSSN` transition in the `SSNListProxy` contract. |
+|`SubmitCustomUpdateSSNTransaction`| `calleeContract : ByStr20, ssnaddr : ByStr20, new_name : String, new_urlraw : String, new_urlapi : String` | Submit a request to invoke the `UpdateSSN` transition in the `SSNListProxy` contract. |
+|`SubmitCustomAddSSNAfterUpgradeTransaction` | `calleeContract: ByStr20, ssnaddr: ByStr20, stake_amt: Uint128, rewards: Uint128, name: String, urlraw: String, urlapi: String, buff_deposit: Uint128, comm: Uint128, comm_rewards: Uint128, rec_addr: ByStr20` | Submit a request to invoke the `AddSSNAfterUpgrade` transition in the `SSNListProxy` contract. |
+|`SubmitUpdateDelegTransaction` | `calleeContract: ByStr20, ssnaddr: ByStr20, deleg: ByStr20, stake_amt: Uint128` | Submit a request to invoke the `UpdateDeleg` transition in the `SSNListProxy` contract. |
+|`SubmitPopulateStakeSSNPerCycleTransaction`| `calleeContract : ByStr20, ssn_address : ByStr20, cycle : Uint32, info : SSNCycleInfo` | Submit a request to invoke the `PopulateStakeSSNPerCycle` transition in the `SSNListProxy` contract. |
+|`SubmitPopulateLastWithdrawCycleFordelegTransaction`| `calleeContract : ByStr20, deleg_address : ByStr20, ssn_address : ByStr20, cycle : Uint32` | Submit a request to invoke the `PopulateLastWithdrawCycleFordeleg` transition in the `SSNListProxy` contract. |
+|`SubmitPopulateBufferedDepositTransaction`| `calleeContract : ByStr20, deleg_address : ByStr20, ssn_address : ByStr20, cycle : Uint32, amount : Uint128` | Submit a request to invoke the `PopulateBufferedDeposit` transition in the `SSNListProxy` contract. |
+|`SubmitPopulateDirectDepositTransaction`| `calleeContract : ByStr20, deleg_address : ByStr20, ssn_address : ByStr20, cycle : Uint32, amount : Uint128` | Submit a request to invoke the `PopulateDirectDeposit` transition in the `SSNListProxy` contract. |
+|`SubmitPopulateCommForSSNTransaction`| `calleeContract : ByStr20, ssn_address : ByStr20, cycle : Uint32, comm : Uint128` | Submit a request to invoke the `PopulateCommForSSN` transition in the `SSNListProxy` contract. |
+|`SubmitPopulateTotalStakeAmtTransaction`| `calleeContract : ByStr20, amt : Uint128` | Submit a request to invoke the `PopulateTotalStakeAmt` transition in the `SSNListProxy` contract. |
+|`SubmitCustomRemoveSSNTransaction`| `calleeContract : ByStr20, ssnaddr : ByStr20` | Submit a request to invoke the `RemoveSSN` transition in the `SSNListProxy` contract. |
+|`SubmitPopulateDepositAmountFordelegTransaction`| `calleeContract : ByStr20, deleg_address : ByStr20, ssn_address : ByStr20, amount : Uint128` | Submit a request to invoke the `PopulateDepositAmountFordeleg` transition in the `SSNListProxy` contract. |
+|`SubmitCustomDrainContractBalanceTransaction`| `calleeContract : ByStr20, amt : Uint128` | Submit a request to invoke the `DrainContractBalance` transition in the `SSNListProxy` contract. |
 
 ### Action Transitions
 

--- a/contracts/multisig_wallet.scilla
+++ b/contracts/multisig_wallet.scilla
@@ -77,7 +77,7 @@ type SsnRewardShare =
 
 (* Type of Proxy transactions. *)
 (* All calls are made to the proxy contract *)
-type ProxyTransaction =
+type CalleeTransaction =
 (***************************************************)
 (*               Proxy Transition                  *)
 (***************************************************)
@@ -148,7 +148,7 @@ type Transaction =
 (* Transfer of native tokens *)
 | NativeTransaction of ByStr20 Uint128 String
 (* Custom token transactions *)
-| CustomTransaction of ByStr20 ProxyTransaction
+| CustomTransaction of ByStr20 CalleeTransaction
 
 (* Make map of owners *)
 let mk_owners_map =
@@ -179,59 +179,59 @@ let native_transaction_msg_as_list =
 
 (* Create custom transaction message as singleton list *)
 let custom_transaction_msg_as_list =
-  fun (proxyContract : ByStr20) =>
-  fun (proxyTransaction : ProxyTransaction) =>
+  fun (calleeContract : ByStr20) =>
+  fun (calleeTransaction : CalleeTransaction) =>
     let msg =
-      match proxyTransaction with
+      match calleeTransaction with
         (* UpgradeTo(newImplementation: ByStr20) *)
       | UpgradeTo newImplementation =>
-        {_recipient: proxyContract ;
+        {_recipient: calleeContract ;
          _tag: "UpgradeTo";
          _amount: Uint128 0;
          newImplementation : newImplementation}
         (* ChangeProxyAdmin(newAdmin: ByStr20) *)
       | ChangeProxyAdmin newAdmin =>
-        {_recipient: proxyContract;
+        {_recipient: calleeContract;
          _tag: "ChangeProxyAdmin";
          _amount: Uint128 0;
          newAdmin: newAdmin}
         (* ChangeMinter(new_minter: ByStr20) *)
       | ChangeMinter new_minter =>
-        {_recipient: proxyContract;
+        {_recipient: calleeContract;
          _tag: "ChangeMinter";
          _amount: Uint128 0;
          new_minter: new_minter}
         (* Pause() *)
       | Pause =>
-        {_recipient: proxyContract;
+        {_recipient: calleeContract;
          _tag: "Pause";
          _amount: Uint128 0}
         (* UnPause() *)
       | UnPause =>
-        {_recipient: proxyContract ;
+        {_recipient: calleeContract ;
          _tag: "UnPause";
          _amount: Uint128 0}
         (* UpdateAdmin(new_admin: ByStr20) *)
       | UpdateAdmin new_admin =>
-        {_recipient: proxyContract;
+        {_recipient: calleeContract;
          _tag: "UpdateAdmin";
          _amount: Uint128 0;
          new_admin: new_admin}
         (* UpdateVerifier(verif: ByStr20)  *)
       | UpdateVerifier verif =>
-        {_recipient: proxyContract;
+        {_recipient: calleeContract;
          _tag: "UpdateVerifier";
          _amount: Uint128 0;
          verif: verif}
         (* UpdateVerifierRewardAddr(addr: ByStr20) *)
       | UpdateVerifierRewardAddr addr =>
-        {_recipient : proxyContract;
+        {_recipient : calleeContract;
          _tag: "UpdateVerifierRewardAddr";
          _amount: Uint128 0;
          addr: addr}
         (* UpdateStakingParameters(min_stake: Uint128, min_deleg_stake: Uint128, max_comm_change_rate: Uint128) *)
       | UpdateStakingParameters min_stake min_deleg_stake max_comm_change_rate =>
-        {_recipient : proxyContract;
+        {_recipient : calleeContract;
          _tag: "UpdateStakingParameters";
          _amount: Uint128 0;
          min_stake: min_stake;
@@ -239,19 +239,19 @@ let custom_transaction_msg_as_list =
          max_comm_change_rate: max_comm_change_rate}
         (* ChangeBNumReq(input_bnum_req: Uint128) *)
       | ChangeBNumReq input_bnum_req =>
-        {_recipient : proxyContract;
+        {_recipient : calleeContract;
          _tag: "ChangeBNumReq";
          _amount: Uint128 0;
          input_bnum_req: input_bnum_req}
         (* UpdateGzilAddr(gzil_addr: ByStr20) *)
       | UpdateGzilAddr gzil_addr  =>
-        {_recipient : proxyContract;
+        {_recipient : calleeContract;
          _tag: "UpdateGzilAddr";
          _amount: Uint128 0;
          gzil_addr: gzil_addr}
         (* AddSSN(ssnaddr: ByStr20, name: String, urlraw: String, urlapi: String, comm: Uint128) *)
       | AddSSN ssnaddr name urlraw urlapi comm =>
-        {_recipient : proxyContract;
+        {_recipient : calleeContract;
          _tag: "AddSSN";
          _amount: Uint128 0;
          ssnaddr: ssnaddr;
@@ -261,7 +261,7 @@ let custom_transaction_msg_as_list =
          comm: comm}
         (* UpdateSSN(ssnaddr: ByStr20, new_name: String, new_urlraw: String, new_urlapi: String) *)
       | UpdateSSN ssnaddr new_name new_urlraw new_urlapi =>
-        {_recipient : proxyContract;
+        {_recipient : calleeContract;
          _tag: "UpdateSSN";
          _amount: Uint128 0;
          ssnaddr: ssnaddr;
@@ -270,13 +270,13 @@ let custom_transaction_msg_as_list =
          new_urlapi: new_urlapi}
         (* transition RemoveSSN(ssnaddr: ByStr20) *) 
       | RemoveSSN ssnaddr =>
-        {_recipient: proxyContract ;
+        {_recipient: calleeContract ;
         _tag: "RemoveSSN";
         _amount: Uint128 0;
         ssnaddr: ssnaddr}
         (* AddSSNAfterUpgrade(ssnaddr: ByStr20, stake_amt: Uint128, rewards: Uint128, name: String, urlraw: String, urlapi: String, buff_deposit: Uint128, comm: Uint128, comm_rewards: Uint128, rec_addr: ByStr20) *)
       | AddSSNAfterUpgrade ssnaddr stake_amt rewards name urlraw urlapi buff_deposit comm comm_rewards rec_addr =>
-        {_recipient : proxyContract;
+        {_recipient : calleeContract;
          _tag: "AddSSNAfterUpgrade";
          _amount: Uint128 0;
          ssnaddr: ssnaddr;
@@ -291,7 +291,7 @@ let custom_transaction_msg_as_list =
          rec_addr: rec_addr}
         (* UpdateDeleg(ssnaddr: ByStr20, deleg: ByStr20, stake_amt: Uint128) *)
       | UpdateDeleg ssnaddr deleg stake_amt =>
-        {_recipient : proxyContract;
+        {_recipient : calleeContract;
          _tag: "UpdateDeleg";
          _amount: Uint128 0;
          ssnaddr: ssnaddr;
@@ -299,7 +299,7 @@ let custom_transaction_msg_as_list =
          stake_amt: stake_amt}
         (* PopulateStakeSSNPerCycle(ssn_addr: ByStr20, cycle: Uint32, info: SSNCycleInfo) *)
       | PopulateStakeSSNPerCycle ssn_address cycle info =>
-        {_recipient: proxyContract;
+        {_recipient: calleeContract;
          _tag: "PopulateStakeSSNPerCycle";
          _amount : Uint128 0;
          ssn_address: ssn_address;
@@ -307,7 +307,7 @@ let custom_transaction_msg_as_list =
          info: info}
         (* PopulateLastWithdrawCycleForDeleg(deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint32) *)
       | PopulateLastWithdrawCycleForDeleg deleg_addr ssn_addr cycle =>
-        {_recipient: proxyContract;
+        {_recipient: calleeContract;
          _tag: "PopulateLastWithdrawCycleFordeleg";
          _amount: Uint128 0;
          deleg_addr: deleg_addr;
@@ -315,7 +315,7 @@ let custom_transaction_msg_as_list =
          cycle: cycle}
         (* PopulateBuffDeposit(deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint32, amt: Uint128) *)
       | PopulateBuffDeposit deleg_addr ssn_addr cycle amt =>
-        {_recipient: proxyContract;
+        {_recipient: calleeContract;
          _tag: "PopulateBuffDeposit";
          _amount: Uint128 0;
          deleg_addr: deleg_addr;
@@ -324,7 +324,7 @@ let custom_transaction_msg_as_list =
          amt: amt}
         (* PopulateDirectDeposit(deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint32, amt: Uint128) *)
       | PopulateDirectDeposit deleg_addr ssn_addr cycle amt =>
-        {_recipient: proxyContract;
+        {_recipient: calleeContract;
          _tag: "PopulateDirectDeposit";
          _amount: Uint128 0;
          deleg_addr: deleg_addr;
@@ -333,7 +333,7 @@ let custom_transaction_msg_as_list =
          amt: amt}
         (* PopulateCommForSSN(ssn_addr: ByStr20, cycle: Uint32, comm: Uint128) *)
       | PopulateCommForSSN ssn_addr cycle comm =>
-        {_recipient : proxyContract;
+        {_recipient : calleeContract;
          _tag: "PopulateCommForSSN";
          _amount: Uint128 0;
          ssn_addr: ssn_addr;
@@ -341,13 +341,13 @@ let custom_transaction_msg_as_list =
          comm: comm}
         (* PopulateTotalStakeAmt(amt: Uint128) *)
       | PopulateTotalStakeAmt amt =>
-        {_recipient: proxyContract;
+        {_recipient: calleeContract;
          _tag: "PopulateTotalStakeAmt";
          _amount: Uint128 0;
          amt: amt}
         (* DrainContractBalance(amt: Uint128) *)
       | DrainContractBalance amt =>
-        {_recipient : proxyContract;
+        {_recipient : calleeContract;
          _tag : "DrainContractBalance";
          _amount : Uint128 0;
          amt: amt}
@@ -536,8 +536,8 @@ transition SubmitNativeTransaction (recipient : ByStr20, amount : Uint128, tag :
 end
 
 (* Common submit procedure for custom transactions *)
-procedure SubmitCustomTransaction (proxyContract : ByStr20, proxyTransaction : ProxyTransaction)
-  transaction = CustomTransaction proxyContract proxyTransaction;
+procedure SubmitCustomTransaction (calleeContract : ByStr20, calleeTransaction : CalleeTransaction)
+  transaction = CustomTransaction calleeContract calleeTransaction;
   SubmitTransaction transaction
 end
 
@@ -546,24 +546,24 @@ end
 (***************************************************)
 
 (* Submit a new UpgradeTo transaction for future signoff *)
-transition SubmitCustomUpgradeToTransaction (proxyContract : ByStr20, newImplementation : ByStr20)
+transition SubmitCustomUpgradeToTransaction (calleeContract : ByStr20, newImplementation : ByStr20)
   transaction = UpgradeTo newImplementation;
-  SubmitCustomTransaction proxyContract transaction
+  SubmitCustomTransaction calleeContract transaction
 end
 
 (* Submit a new ChangeProxyAdmin transaction for future signoff *)
-transition SubmitCustomChangeProxyAdminTransaction (proxyContract : ByStr20, newAdmin : ByStr20)
+transition SubmitCustomChangeProxyAdminTransaction (calleeContract : ByStr20, newAdmin : ByStr20)
   transaction = ChangeProxyAdmin newAdmin;
-  SubmitCustomTransaction proxyContract transaction
+  SubmitCustomTransaction calleeContract transaction
 end
 
 (***************************************************)
 (*              gZIL Transitions                   *)
 (***************************************************)
 
-transition SubmitCustomChangeMinterTransaction (proxyContract : ByStr20, new_minter : ByStr20)
+transition SubmitCustomChangeMinterTransaction (calleeContract : ByStr20, new_minter : ByStr20)
   transaction = ChangeMinter new_minter;
-  SubmitCustomTransaction proxyContract transaction
+  SubmitCustomTransaction calleeContract transaction
 end
 
 (***************************************************)
@@ -576,69 +576,69 @@ end
 (***************************************************)
 
 (* Submit a new pause transaction for future signoff *)
-transition SubmitCustomPauseTransaction(proxyContract: ByStr20)
+transition SubmitCustomPauseTransaction(calleeContract: ByStr20)
   transaction = Pause;
-  SubmitCustomTransaction proxyContract transaction
+  SubmitCustomTransaction calleeContract transaction
 end
 
 (* Submit a new unpause transaction for future signoff *)
-transition SubmitCustomUnpauseTransaction(proxyContract: ByStr20)
+transition SubmitCustomUnpauseTransaction(calleeContract: ByStr20)
   transaction = UnPause;
-  SubmitCustomTransaction proxyContract transaction
+  SubmitCustomTransaction calleeContract transaction
 end
 
 (* Submit a new UpdateAdmin transaction for future signoff *)
-transition SubmitCustomUpdateAdminTransaction(proxyContract: ByStr20, new_admin: ByStr20)
+transition SubmitCustomUpdateAdminTransaction(calleeContract: ByStr20, new_admin: ByStr20)
   transaction = UpdateAdmin new_admin;
-  SubmitCustomTransaction proxyContract transaction
+  SubmitCustomTransaction calleeContract transaction
 end
 
 (* Submit a new UpdateVerifier transaction for future signoff *)
-transition SubmitCustomUpdateVerifierTransaction(proxyContract: ByStr20, verif: ByStr20)
+transition SubmitCustomUpdateVerifierTransaction(calleeContract: ByStr20, verif: ByStr20)
   transaction = UpdateVerifier verif;
-  SubmitCustomTransaction proxyContract transaction
+  SubmitCustomTransaction calleeContract transaction
 end
 
 (* Submit a new UpdateVerifierRewardAddr transaction for future signoff *)
-transition SubmitCustomUpdateVerifierRewardAddrTransaction(proxyContract: ByStr20, addr: ByStr20)
+transition SubmitCustomUpdateVerifierRewardAddrTransaction(calleeContract: ByStr20, addr: ByStr20)
   transaction = UpdateVerifierRewardAddr addr;
-  SubmitCustomTransaction proxyContract transaction
+  SubmitCustomTransaction calleeContract transaction
 end
 
 (* Submit a new ContractStakingParameter transaction for future signoff *)
-transition SubmitCustomUpdateStakingParametersTransaction(proxyContract: ByStr20, min_stake: Uint128, min_deleg_stake: Uint128, max_comm_change_rate: Uint128)
+transition SubmitCustomUpdateStakingParametersTransaction(calleeContract: ByStr20, min_stake: Uint128, min_deleg_stake: Uint128, max_comm_change_rate: Uint128)
   transaction = UpdateStakingParameters min_stake min_deleg_stake max_comm_change_rate;
-  SubmitCustomTransaction proxyContract transaction
+  SubmitCustomTransaction calleeContract transaction
 end
 
 (* Submit a new ChangeBNumReq transaction for future signoff *)
-transition SubmitCustomChangeBNumReqTransaction(proxyContract: ByStr20, input_bnum_req: Uint128)
+transition SubmitCustomChangeBNumReqTransaction(calleeContract: ByStr20, input_bnum_req: Uint128)
   transaction = ChangeBNumReq input_bnum_req;
-  SubmitCustomTransaction proxyContract transaction
+  SubmitCustomTransaction calleeContract transaction
 end
 
 (* Submit a new UpdateGzilAddr transaction for future signoff *)
-transition SubmitCustomUpdateGzilAddrTransaction(proxyContract: ByStr20, gzil_addr: ByStr20)
+transition SubmitCustomUpdateGzilAddrTransaction(calleeContract: ByStr20, gzil_addr: ByStr20)
   transaction = UpdateGzilAddr gzil_addr;
-  SubmitCustomTransaction proxyContract transaction
+  SubmitCustomTransaction calleeContract transaction
 end
 
 (* Submit a new AddSSN transaction for future signoff *)
-transition SubmitCustomAddSSNTransaction(proxyContract: ByStr20, ssnaddr: ByStr20, name: String, urlraw: String, urlapi: String, comm: Uint128)
+transition SubmitCustomAddSSNTransaction(calleeContract: ByStr20, ssnaddr: ByStr20, name: String, urlraw: String, urlapi: String, comm: Uint128)
   transaction = AddSSN ssnaddr name urlraw urlapi comm;
-  SubmitCustomTransaction proxyContract transaction
+  SubmitCustomTransaction calleeContract transaction
 end
 
 (* Submit a new UpdateSSN transaction for future signoff *)
-transition SubmitCustomUpdateSSNTransaction(proxyContract: ByStr20, ssnaddr: ByStr20, new_name: String, new_urlraw: String, new_urlapi: String)
+transition SubmitCustomUpdateSSNTransaction(calleeContract: ByStr20, ssnaddr: ByStr20, new_name: String, new_urlraw: String, new_urlapi: String)
   transaction = UpdateSSN ssnaddr new_name new_urlraw new_urlapi;
-  SubmitCustomTransaction proxyContract transaction
+  SubmitCustomTransaction calleeContract transaction
 end
 
 (* Submit a new AddSSNAfterUpgrade transaction for future signoff *)
-transition SubmitCustomAddSSNAfterUpgradeTransaction(proxyContract: ByStr20, ssnaddr: ByStr20, stake_amt: Uint128, rewards: Uint128, name: String, urlraw: String, urlapi: String, buff_deposit: Uint128, comm: Uint128, comm_rewards: Uint128, rec_addr: ByStr20)
+transition SubmitCustomAddSSNAfterUpgradeTransaction(calleeContract: ByStr20, ssnaddr: ByStr20, stake_amt: Uint128, rewards: Uint128, name: String, urlraw: String, urlapi: String, buff_deposit: Uint128, comm: Uint128, comm_rewards: Uint128, rec_addr: ByStr20)
   transaction = AddSSNAfterUpgrade ssnaddr stake_amt rewards name urlraw urlapi buff_deposit comm comm_rewards rec_addr;
-  SubmitCustomTransaction proxyContract transaction
+  SubmitCustomTransaction calleeContract transaction
 end
 
 (***************************************************)
@@ -647,57 +647,57 @@ end
 
 
 (* Submit a new UpdateDeleg transaction for future signoff *)
-transition SubmitUpdateDelegTransaction(proxyContract: ByStr20, ssnaddr: ByStr20, deleg: ByStr20, stake_amt: Uint128)
+transition SubmitUpdateDelegTransaction(calleeContract: ByStr20, ssnaddr: ByStr20, deleg: ByStr20, stake_amt: Uint128)
   transaction = UpdateDeleg ssnaddr deleg stake_amt;
-  SubmitCustomTransaction proxyContract transaction
+  SubmitCustomTransaction calleeContract transaction
 end
 
 (* Submit a new PopulateStakeSSNPerCycle transaction for future signoff *)
-transition SubmitPopulateStakeSSNPerCycleTransaction(proxyContract: ByStr20, ssn_addr: ByStr20, cycle: Uint32, info: SSNCycleInfo)
+transition SubmitPopulateStakeSSNPerCycleTransaction(calleeContract: ByStr20, ssn_addr: ByStr20, cycle: Uint32, info: SSNCycleInfo)
   transaction = PopulateStakeSSNPerCycle ssn_addr cycle info;
-  SubmitCustomTransaction proxyContract transaction
+  SubmitCustomTransaction calleeContract transaction
 end
 
 (* Submit a new PopulateLastWithdrawCycleFordeleg transaction for future signoff *)
-transition SubmitPopulateLastWithdrawCycleFordelegTransaction(proxyContract: ByStr20, deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint32)
+transition SubmitPopulateLastWithdrawCycleFordelegTransaction(calleeContract: ByStr20, deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint32)
   transaction = PopulateLastWithdrawCycleForDeleg deleg_addr ssn_addr cycle;
-  SubmitCustomTransaction proxyContract transaction
+  SubmitCustomTransaction calleeContract transaction
 end
 
 (* Submit a new PopulateBuffDeposit transaction for future signoff *)
-transition SubmitPopulateBuffDepositTransaction(proxyContract: ByStr20, deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint32, amt: Uint128)
+transition SubmitPopulateBuffDepositTransaction(calleeContract: ByStr20, deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint32, amt: Uint128)
   transaction = PopulateBuffDeposit deleg_addr ssn_addr cycle amt;
-  SubmitCustomTransaction proxyContract transaction
+  SubmitCustomTransaction calleeContract transaction
 end
 
 (* Submit a new PopulateDirectDeposit transaction for future signoff *)
-transition SubmitPopulateDirectDepositTransaction(proxyContract: ByStr20, deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint32, amt: Uint128)
+transition SubmitPopulateDirectDepositTransaction(calleeContract: ByStr20, deleg_addr: ByStr20, ssn_addr: ByStr20, cycle: Uint32, amt: Uint128)
   transaction = PopulateDirectDeposit deleg_addr ssn_addr cycle amt;
-  SubmitCustomTransaction proxyContract transaction
+  SubmitCustomTransaction calleeContract transaction
 end
 
 (* Submit a new PopulateCommForSSN transaction for future signoff *)
-transition SubmitPopulateCommForSSNTransaction(proxyContract: ByStr20, ssn_addr: ByStr20, cycle: Uint32, comm: Uint128)
+transition SubmitPopulateCommForSSNTransaction(calleeContract: ByStr20, ssn_addr: ByStr20, cycle: Uint32, comm: Uint128)
   transaction = PopulateCommForSSN ssn_addr cycle comm;
-  SubmitCustomTransaction proxyContract transaction
+  SubmitCustomTransaction calleeContract transaction
 end
 
 (* Submit a new PopulateTotalStakeAmt transaction for future signoff *)
-transition SubmitPopulateTotalStakeAmtTransaction(proxyContract: ByStr20, amt: Uint128)
+transition SubmitPopulateTotalStakeAmtTransaction(calleeContract: ByStr20, amt: Uint128)
   transaction = PopulateTotalStakeAmt amt;
-  SubmitCustomTransaction proxyContract transaction
+  SubmitCustomTransaction calleeContract transaction
 end
 
 (* Submit a new AddSSN transaction for future signoff *)
-transition SubmitCustomRemoveSSNTransaction(proxyContract: ByStr20, ssnaddr: ByStr20)
+transition SubmitCustomRemoveSSNTransaction(calleeContract: ByStr20, ssnaddr: ByStr20)
   transaction = RemoveSSN ssnaddr;
-  SubmitCustomTransaction proxyContract transaction
+  SubmitCustomTransaction calleeContract transaction
 end
 
 (* Submit a new DrainContractBalance transaction for future signoff *)
-transition SubmitCustomDrainContractBalanceTransaction(proxyContract : ByStr20, amt: Uint128)
+transition SubmitCustomDrainContractBalanceTransaction(calleeContract : ByStr20, amt: Uint128)
   transaction = DrainContractBalance amt;
-  SubmitCustomTransaction proxyContract transaction
+  SubmitCustomTransaction calleeContract transaction
 end
 
 (* Sign off on an existing transaction *)
@@ -791,7 +791,7 @@ end
 (* Execute custom transaction. *)
 (* Checks permission to execute. *)
 (* Assumes the transaction has been signed off by enough owners. *)
-procedure ExecuteCustomTransaction (proxyContract : ByStr20, proxyTransaction : ProxyTransaction)
+procedure ExecuteCustomTransaction (calleeContract : ByStr20, calleeTransaction : CalleeTransaction)
   (* Only owners may execute *)
   sender_is_owner <- exists owners[_sender];
   match sender_is_owner with
@@ -799,7 +799,7 @@ procedure ExecuteCustomTransaction (proxyContract : ByStr20, proxyTransaction : 
     err = SenderMayNotExecute;
     MakeError err
   | True =>
-    as_msg = custom_transaction_msg_as_list proxyContract proxyTransaction;
+    as_msg = custom_transaction_msg_as_list calleeContract calleeTransaction;
     send as_msg
   end
 end
@@ -829,8 +829,8 @@ transition ExecuteTransaction (transactionId : Uint32)
         match transaction with
         | NativeTransaction recipient amount tag =>
           ExecuteNativeTransaction recipient amount tag
-        | CustomTransaction proxyContract proxyTransaction =>
-          ExecuteCustomTransaction proxyContract proxyTransaction
+        | CustomTransaction calleeContract calleeTransaction =>
+          ExecuteCustomTransaction calleeContract calleeTransaction
         end;
         (* Remove transaction and signatures. *)
         (* Note: The transaction may have failed, but without a callback *)

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -476,7 +476,7 @@ procedure CalculateTotalWithdrawal(withdraw: Pair BNum Uint128)
       | False => 
       end
     end
-  | None => (* Won't reach *)
+  | None => throw
   end
 end
 
@@ -810,7 +810,7 @@ procedure WithdrawalStakeRewards(deleg: ByStr20, ssn_operator: ByStr20)
     rest_rewards = builtin sub total_rewards reward;
     ssn = Ssn active_status stake_amt rest_rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr;
     ssnlist[ssn_operator] := ssn
-  | None => (* won't reach *)
+  | None => throw
   end;
   e = { _eventname: "WithdrawalStakeRewards"; rewards: reward};
   event e;

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -476,7 +476,7 @@ procedure CalculateTotalWithdrawal(withdraw: Pair BNum Uint128)
       | False => 
       end
     end
-  | None => throw
+  | None => (* Won't reach *)
   end
 end
 

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -1151,6 +1151,7 @@ transition CompleteWithdrawal(initiator: ByStr20)
   | None =>
     e = { _eventname: "NoPendingWithdrawal"; ssnaddr: initiator };
     event e
+  end
 end
 
 transition ReDelegateStake(ssnaddr: ByStr20, to_ssn: ByStr20, amount: Uint128, initiator: ByStr20)

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -379,7 +379,7 @@ procedure DecreaseTotalStakeAmtOnStatus(amt: Uint128, status: Bool)
   end
 end
 
-procedure EmitSsnEventOnStausChange(ssnaddr: String, old_status: Bool, new_status: Bool)
+procedure EmitSsnEventOnStausChange(ssnaddr: ByStr20, old_status: Bool, new_status: Bool)
   match old_status with
   | True =>
     match new_status with

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -558,7 +558,7 @@ procedure FillInDepositDelegAmt(ssnaddr: ByStr20, deleg: ByStr20, amount: Uint12
   end
 end
 
-procedure HasRewardToWithdraw(ssnaddr: ByStr20, deleg: ByStr20, total_rewards: Uint128)
+procedure AssertNoRewards(ssnaddr: ByStr20, deleg: ByStr20, total_rewards: Uint128)
   no_total_rewards = builtin eq total_rewards uint128_zero;
   match no_total_rewards with
   | True =>
@@ -576,7 +576,7 @@ procedure HasRewardToWithdraw(ssnaddr: ByStr20, deleg: ByStr20, total_rewards: U
   end
 end
 
-procedure HasBufferedDeposit(ssnaddr: ByStr20, deleg: ByStr20)
+procedure AsseertNoBufferedDeposit(ssnaddr: ByStr20, deleg: ByStr20)
   ldcd_o <- last_buf_deposit_cycle_deleg[deleg][ssnaddr];
   ldcd = option_uint32_value ldcd_o;
   lrc <- lastrewardcycle;
@@ -629,7 +629,7 @@ procedure AdjustDeleg(ssnaddr: ByStr20, deleg: ByStr20, total_amount: Uint128, w
   end
 end
 
-procedure ReDelegStakeAmt(initiator: ByStr20, ssn: ByStr20, redeleg_amt: Uint128)
+procedure UnDelegateStakeAmt(initiator: ByStr20, ssn: ByStr20, redeleg_amt: Uint128)
   ssn_o <- ssnlist[ssn];
   deleg <- deposit_amt_deleg[initiator][ssn];
   lrc <- lastrewardcycle;
@@ -637,8 +637,8 @@ procedure ReDelegStakeAmt(initiator: ByStr20, ssn: ByStr20, redeleg_amt: Uint128
   | Some (Ssn active_status stake_amt rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr) =>
     match deleg with
     | Some amt =>
-      HasRewardToWithdraw ssn initiator rewards;
-      HasBufferedDeposit ssn initiator;
+      AssertNoRewards ssn initiator rewards;
+      AsseertNoBufferedDeposit ssn initiator;
       AdjustDeleg ssn initiator amt redeleg_amt;
       (* Illegal withdraw amount could be handled in procedure AdjustDeleg *)
       DecreaseTotalStakeAmt redeleg_amt;
@@ -669,8 +669,8 @@ procedure WithdrawalStakeAmt(initiator: ByStr20, ssn: ByStr20, withdraw_amount: 
   | Some (Ssn active_status stake_amt rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr) =>
     match deleg with
     | Some amt =>
-      HasRewardToWithdraw ssn initiator rewards;
-      HasBufferedDeposit ssn initiator;
+      AssertNoRewards ssn initiator rewards;
+      AsseertNoBufferedDeposit ssn initiator;
       AdjustDeleg ssn initiator amt withdraw_amount;
       (* Illegal withdraw amount could be handled in procedure AdjustDeleg *)
       DecreaseTotalStakeAmt withdraw_amount;
@@ -1135,7 +1135,7 @@ transition ReDelegateStake(ssnaddr: ByStr20, to_ssn: ByStr20, amount: Uint128, i
     e = ReDelegInvalidSSNAddr;
     ThrowError e
   | False =>
-    ReDelegStakeAmt initiator ssnaddr amount;
+    UnDelegateStakeAmt initiator ssnaddr amount;
     Delegate to_ssn initiator amount;
     e = { _eventname: "ReDelegateStakeSuccess"; ssnaddr: ssnaddr; to_ssn: to_ssn; delegator: initiator; delegate_amount: amount };
     event e

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -956,6 +956,7 @@ transition AddSSN(ssnaddr: ByStr20, name: String, urlraw: String, urlapi: String
     e = SSNAlreadyExist;
     ThrowError e
   | False =>
+    ValidateRate comm;
     status = bool_inactive;
     stake_amt = Uint128 0;
     rewards = Uint128 0;

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -1145,7 +1145,7 @@ transition CompleteWithdrawal(initiator: ByStr20)
     e = { _eventname: "CompleteWithdrawal"; ssnaddr: initiator; withdraw_amt: withdraw_amt };
     event e;
     TransferFunds addfunds_tag withdraw_amt initiator
-  | None =>
+  | None => throw
   end
 end
 

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -1142,7 +1142,7 @@ transition CompleteWithdrawal(initiator: ByStr20)
     (* Calculate withdrawal that can be transferred *)
     forall withdraw_list CalculateTotalWithdrawal;
     withdraw_amt <- avaiable_withdrawal;
-    e = { _eventname: "CompleteWithdrawal"; ssn_addr: initiator; initiator: withdraw_amt };
+    e = { _eventname: "CompleteWithdrawal"; ssnaddr: initiator; withdraw_amt: withdraw_amt };
     event e;
     TransferFunds addfunds_tag withdraw_amt initiator
   | None =>

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -379,6 +379,25 @@ procedure DecreaseTotalStakeAmtOnStatus(amt: Uint128, status: Bool)
   end
 end
 
+procedure EmitSsnEventOnStausChange(ssnaddr: String, old_status: Bool, new_status: Bool)
+  match old_status with
+  | True =>
+    match new_status with
+    | True =>
+    | False => 
+      e = { _eventname: "SSN becomes inactive"; ssnaddr: ssnaddr };
+      event e
+    end
+  | False =>
+    match new_status with
+    | True =>
+      e = { _eventname: "SSN becomes active"; ssnaddr: ssnaddr };
+      event e
+    | False =>
+    end
+  end
+end
+
 (* Check if the initiator is verifier *)
 procedure CallerIsVerifier(initiator: ByStr20)
   verifier_tmp <- verifier;
@@ -649,6 +668,7 @@ procedure UnDelegateStakeAmt(initiator: ByStr20, ssn: ByStr20, redeleg_amt: Uint
       ssnlist[ssn] := ssn_option_tmp;
       (* If ssn becomes inactive, we need to decrease the rest ones also *)
       DecreaseTotalStakeAmtOnStatus new_amt status;
+      EmitSsnEventOnStausChange ssn active_status status;
       e = { _eventname: "Remove delegate from SSN"; ssn_addr: ssn; deleg_address: initiator; amt: redeleg_amt };
       event e
     | None =>
@@ -681,6 +701,7 @@ procedure WithdrawalStakeAmt(initiator: ByStr20, ssn: ByStr20, withdraw_amount: 
       ssnlist[ssn] := ssn_option_tmp;
       (* If ssn becomes inactive, we need to decrease the rest ones also *)
       DecreaseTotalStakeAmtOnStatus new_amt status;
+      EmitSsnEventOnStausChange ssn active_status status;
       withdrawal_bnum <- & BLOCKNUMBER;
       withdraw_amt_o <- withdrawal_pending[initiator][withdrawal_bnum];
       withdraw_amt_pending = match withdraw_amt_o with
@@ -835,6 +856,7 @@ procedure Delegate(ssnaddr: ByStr20, initiator: ByStr20, amount: Uint128)
       ssnlist[ssnaddr] := ssn;
       (* If ssn becomes active, then we need to increase totalstakeamount *)
       IncreaseTotalStakeAmtOnStatus new_stake_amt status;
+      EmitSsnEventOnStausChange ssnaddr active_status status;
       (* record this to direct deposit for deleg *)
       stake_amt_for_deleg_option  <- direct_deposit_deleg[initiator][ssnaddr][lrc];
       match stake_amt_for_deleg_option  with

--- a/tests/ssnlist.scilla
+++ b/tests/ssnlist.scilla
@@ -241,7 +241,7 @@ match status with
 DecreaseTotalStakeAmt amt
 end
 end
-procedure EmitSsnEventOnStausChange(ssnaddr: String, old_status: Bool, new_status: Bool)
+procedure EmitSsnEventOnStausChange(ssnaddr: ByStr20, old_status: Bool, new_status: Bool)
 match old_status with
 | True =>
 match new_status with

--- a/tests/ssnlist.scilla
+++ b/tests/ssnlist.scilla
@@ -327,7 +327,7 @@ avaiable_withdrawal := current_amt
 | False =>
 end
 end
-| None =>
+| None => throw
 end
 end
 procedure UpdateStakeReward(entry: SsnRewardShare)
@@ -611,7 +611,7 @@ match ssn_o with
 rest_rewards = builtin sub total_rewards reward;
 ssn = Ssn active_status stake_amt rest_rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr;
 ssnlist[ssn_operator] := ssn
-| None =>
+| None => throw
 end;
 e = { _eventname: "WithdrawalStakeRewards"; rewards: reward};
 event e;

--- a/tests/ssnlist.scilla
+++ b/tests/ssnlist.scilla
@@ -855,7 +855,7 @@ c = Some {ByStr20} initiator;
 current_deleg := c;
 forall withdraw_list CalculateTotalWithdrawal;
 withdraw_amt <- avaiable_withdrawal;
-e = { _eventname: "CompleteWithdrawal"; ssn_addr: initiator; initiator: withdraw_amt };
+e = { _eventname: "CompleteWithdrawal"; ssnaddr: initiator; withdraw_amt: withdraw_amt };
 event e;
 TransferFunds addfunds_tag withdraw_amt initiator
 | None =>

--- a/tests/ssnlist.scilla
+++ b/tests/ssnlist.scilla
@@ -241,6 +241,24 @@ match status with
 DecreaseTotalStakeAmt amt
 end
 end
+procedure EmitSsnEventOnStausChange(ssnaddr: String, old_status: Bool, new_status: Bool)
+match old_status with
+| True =>
+match new_status with
+| True =>
+| False =>
+e = { _eventname: "SSN becomes inactive"; ssnaddr: ssnaddr };
+event e
+end
+| False =>
+match new_status with
+| True =>
+e = { _eventname: "SSN becomes active"; ssnaddr: ssnaddr };
+event e
+| False =>
+end
+end
+end
 procedure CallerIsVerifier(initiator: ByStr20)
 verifier_tmp <- verifier;
 match verifier_tmp with
@@ -471,6 +489,7 @@ status = uint128_le minstake_tmp new_amt;
 ssn_option_tmp = Ssn status new_amt rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr;
 ssnlist[ssn] := ssn_option_tmp;
 DecreaseTotalStakeAmtOnStatus new_amt status;
+EmitSsnEventOnStausChange ssn active_status status;
 e = { _eventname: "Remove delegate from SSN"; ssn_addr: ssn; deleg_address: initiator; amt: redeleg_amt };
 event e
 | None =>
@@ -500,6 +519,7 @@ status = uint128_le minstake_tmp new_amt;
 ssn_option_tmp = Ssn status new_amt rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr;
 ssnlist[ssn] := ssn_option_tmp;
 DecreaseTotalStakeAmtOnStatus new_amt status;
+EmitSsnEventOnStausChange ssn active_status status;
 withdrawal_bnum <- & BLOCKNUMBER;
 withdraw_amt_o <- withdrawal_pending[initiator][withdrawal_bnum];
 withdraw_amt_pending = match withdraw_amt_o with
@@ -629,6 +649,7 @@ status = uint128_le minstake_tmp new_stake_amt;
 ssn = Ssn status new_stake_amt rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr;
 ssnlist[ssnaddr] := ssn;
 IncreaseTotalStakeAmtOnStatus new_stake_amt status;
+EmitSsnEventOnStausChange ssnaddr active_status status;
 stake_amt_for_deleg_option  <- direct_deposit_deleg[initiator][ssnaddr][lrc];
 match stake_amt_for_deleg_option  with
 | Some stake_amt_for_deleg =>

--- a/tests/ssnlist.scilla
+++ b/tests/ssnlist.scilla
@@ -391,7 +391,7 @@ deposit_amt_deleg[deleg][ssnaddr] := amount;
 ssn_deleg_amt[ssnaddr][deleg] := amount
 end
 end
-procedure HasRewardToWithdraw(ssnaddr: ByStr20, deleg: ByStr20, total_rewards: Uint128)
+procedure AssertNoRewards(ssnaddr: ByStr20, deleg: ByStr20, total_rewards: Uint128)
 no_total_rewards = builtin eq total_rewards uint128_zero;
 match no_total_rewards with
 | True =>
@@ -408,7 +408,7 @@ ThrowError e
 end
 end
 end
-procedure HasBufferedDeposit(ssnaddr: ByStr20, deleg: ByStr20)
+procedure AsseertNoBufferedDeposit(ssnaddr: ByStr20, deleg: ByStr20)
 ldcd_o <- last_buf_deposit_cycle_deleg[deleg][ssnaddr];
 ldcd = option_uint32_value ldcd_o;
 lrc <- lastrewardcycle;
@@ -453,7 +453,7 @@ e = DelegHasNoSufficientAmt;
 ThrowError e
 end
 end
-procedure ReDelegStakeAmt(initiator: ByStr20, ssn: ByStr20, redeleg_amt: Uint128)
+procedure UnDelegateStakeAmt(initiator: ByStr20, ssn: ByStr20, redeleg_amt: Uint128)
 ssn_o <- ssnlist[ssn];
 deleg <- deposit_amt_deleg[initiator][ssn];
 lrc <- lastrewardcycle;
@@ -461,8 +461,8 @@ match ssn_o with
 | Some (Ssn active_status stake_amt rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr) =>
 match deleg with
 | Some amt =>
-HasRewardToWithdraw ssn initiator rewards;
-HasBufferedDeposit ssn initiator;
+AssertNoRewards ssn initiator rewards;
+AsseertNoBufferedDeposit ssn initiator;
 AdjustDeleg ssn initiator amt redeleg_amt;
 DecreaseTotalStakeAmt redeleg_amt;
 new_amt = builtin sub stake_amt redeleg_amt;
@@ -490,8 +490,8 @@ match ssn_o with
 | Some (Ssn active_status stake_amt rewards name urlraw urlapi buffdeposit comm comm_rewards rec_addr) =>
 match deleg with
 | Some amt =>
-HasRewardToWithdraw ssn initiator rewards;
-HasBufferedDeposit ssn initiator;
+AssertNoRewards ssn initiator rewards;
+AsseertNoBufferedDeposit ssn initiator;
 AdjustDeleg ssn initiator amt withdraw_amount;
 DecreaseTotalStakeAmt withdraw_amount;
 new_amt = builtin sub stake_amt withdraw_amount;
@@ -848,7 +848,7 @@ match same_ssn with
 e = ReDelegInvalidSSNAddr;
 ThrowError e
 | False =>
-ReDelegStakeAmt initiator ssnaddr amount;
+UnDelegateStakeAmt initiator ssnaddr amount;
 Delegate to_ssn initiator amount;
 e = { _eventname: "ReDelegateStakeSuccess"; ssnaddr: ssnaddr; to_ssn: to_ssn; delegator: initiator; delegate_amount: amount };
 event e

--- a/tests/ssnlist.scilla
+++ b/tests/ssnlist.scilla
@@ -324,7 +324,7 @@ avaiable_withdrawal := current_amt
 | False =>
 end
 end
-| None => throw
+| None =>
 end
 end
 procedure UpdateStakeReward(entry: SsnRewardShare)
@@ -851,7 +851,6 @@ c = Some {ByStr20} initiator;
 current_deleg := c;
 forall withdraw_list CalculateTotalWithdrawal;
 withdraw_amt <- avaiable_withdrawal;
-
 transfer = builtin eq withdraw_amt uint128_zero;
 match transfer with
 | True =>
@@ -865,6 +864,7 @@ end
 | None =>
 e = { _eventname: "NoPendingWithdrawal"; ssnaddr: initiator };
 event e
+end
 end
 transition ReDelegateStake(ssnaddr: ByStr20, to_ssn: ByStr20, amount: Uint128, initiator: ByStr20)
 IsPaused;

--- a/tests/ssnlist.scilla
+++ b/tests/ssnlist.scilla
@@ -714,6 +714,7 @@ match already_exists with
 e = SSNAlreadyExist;
 ThrowError e
 | False =>
+ValidateRate comm;
 status = bool_inactive;
 stake_amt = Uint128 0;
 rewards = Uint128 0;


### PR DESCRIPTION
This PR is to fix #131  and introduces following changes:

1. Rename `ProxyContract` to `CalleeContract`
2. Rename `ProxyTransaction` to `CalleeTransaction`
3. Rename `HasRewardToWithdraw` to `AssertNoRewards`, rename `HasBufferedDeposit` to `AsseertNoBufferedDeposit`
4. Update readme.md

Also fix #135:

Add a new procedure `EmitSsnEventOnStausChange` to issue event which ssn's status gets changes.

Fix #136:

Validate commission rate while doing `AddSSN`.

Fix #137 

Fix #138