### PR TITLE
audit 6.17

### DIFF
--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -709,6 +709,9 @@ procedure CalcStakeDelegPerCycle(tmp_arg: TmpArg)
     buf_opt <- buff_deposit_deleg[deleg][ssn_operator][last2_reward_cycle];
     comb_opt = option_add cur_opt buf_opt;
 
+    delete direct_deposit_deleg[deleg][ssn_operator][last_reward_cycle];
+    delete buff_deposit_deleg[deleg][ssn_operator][last2_reward_cycle];
+
     last_amt_o <- deleg_stake_per_cycle[deleg][ssn_operator][last_reward_cycle];
     last_amt = option_uint128_value last_amt_o;
     

--- a/tests/ssnlist.scilla
+++ b/tests/ssnlist.scilla
@@ -526,6 +526,8 @@ last2_reward_cycle = sub_one_to_zero last_reward_cycle;
 cur_opt <- direct_deposit_deleg[deleg][ssn_operator][last_reward_cycle];
 buf_opt <- buff_deposit_deleg[deleg][ssn_operator][last2_reward_cycle];
 comb_opt = option_add cur_opt buf_opt;
+delete direct_deposit_deleg[deleg][ssn_operator][last_reward_cycle];
+delete buff_deposit_deleg[deleg][ssn_operator][last2_reward_cycle];
 last_amt_o <- deleg_stake_per_cycle[deleg][ssn_operator][last_reward_cycle];
 last_amt = option_uint128_value last_amt_o;
 match comb_opt with


### PR DESCRIPTION
Fixes #141 by deleting direct and buffered map entries after getting its value.