### PR TITLE
fix: assign rewards should not be paused

### DIFF
--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -1201,7 +1201,7 @@ end
 (* @param ssnrewardlist: List of SsnRewardShare *)
 (* @param initiator: The original caller who called the proxy *)
 transition AssignStakeReward(ssnreward_list: List SsnRewardShare, initiator: ByStr20)
-  IsPaused;
+  IsNotPaused;
   IsProxy;
   CallerIsVerifier initiator;
   lrc <- lastrewardcycle;

--- a/tests/ssnlist.scilla
+++ b/tests/ssnlist.scilla
@@ -894,7 +894,7 @@ event e
 end
 end
 transition AssignStakeReward(ssnreward_list: List SsnRewardShare, initiator: ByStr20)
-IsPaused;
+IsNotPaused;
 IsProxy;
 CallerIsVerifier initiator;
 lrc <- lastrewardcycle;


### PR DESCRIPTION
transition `AssignStakeReward` should be invoked in the condition of `IsNotPaused`.