### PR TITLE
enhance: assert no rewards

### DIFF
--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -620,8 +620,34 @@ procedure AssertNoRewards(ssnaddr: ByStr20, deleg: ByStr20, total_rewards: Uint1
     has_reward = builtin lt lrcd lrc;
     match has_reward with
     | True =>
-      e = DelegHasUnwithdrawRewards;
-      ThrowError e
+      offset = builtin sub lrc lrcd;
+      offset_only_one = builtin eq offset uint32_one;
+      match offset_only_one with
+      | True =>
+        (* if there is only one cycle ahead, and if it only has buffered deposit, then the rewards *)
+        (* could be zero, we should let him go. to identify this case, we need calculate the exact rewards *)
+        last_reward_cycle = builtin sub lrc uint32_one;
+        last2_reward_cycle = sub_one_to_zero last_reward_cycle;
+        cur_opt <- direct_deposit_deleg[deleg][ssnaddr][last_reward_cycle];
+        buf_opt <- buff_deposit_deleg[deleg][ssnaddr][last2_reward_cycle];
+        comb_opt = option_add cur_opt buf_opt;
+        last_amt_o <- deleg_stake_per_cycle[deleg][ssnaddr][last_reward_cycle];
+        last_amt = option_uint128_value last_amt_o;
+        staking_of_deleg = match comb_opt with
+        | Some stake => builtin add last_amt stake
+        | None => last_amt
+        end;
+        no_rewards = builtin eq staking_of_deleg uint128_zero;
+        match no_rewards with
+        | True =>
+        | False =>
+          e = DelegHasUnwithdrawRewards;
+          ThrowError e
+        end
+      | False =>
+        e = DelegHasUnwithdrawRewards;
+        ThrowError e
+      end
     | False =>
     end
   end

--- a/tests/ssnlist.scilla
+++ b/tests/ssnlist.scilla
@@ -318,7 +318,7 @@ end
 procedure CalculateTotalWithdrawal(withdraw: Pair BNum Uint128)
 current_deleg_o <- current_deleg;
 match current_deleg_o with
-| Some current_deleg =>
+| Some deleg =>
 match withdraw with
 | Pair withdraw_number amt =>
 current_bnum <- & BLOCKNUMBER;
@@ -327,15 +327,15 @@ bnum = builtin badd withdraw_number current_bnum_req;
 can_withdraw = builtin blt bnum current_bnum;
 match can_withdraw with
 | True =>
-delete withdrawal_pending[current_deleg][withdraw_number];
+delete withdrawal_pending[deleg][withdraw_number];
 current_amt <- available_withdrawal;
 current_amt = builtin add current_amt amt;
 available_withdrawal := current_amt;
-has_other_records <- withdrawal_pending[current_deleg];
+has_other_records <- withdrawal_pending[deleg];
 match has_other_records with
 | Some inner =>
 | None =>
-delete withdrawal_pending[current_deleg]
+delete withdrawal_pending[deleg]
 end
 | False =>
 end
@@ -442,8 +442,32 @@ lrc <- lastrewardcycle;
 has_reward = builtin lt lrcd lrc;
 match has_reward with
 | True =>
+offset = builtin sub lrc lrcd;
+offset_only_one = builtin eq offset uint32_one;
+match offset_only_one with
+| True =>
+last_reward_cycle = builtin sub lrc uint32_one;
+last2_reward_cycle = sub_one_to_zero last_reward_cycle;
+cur_opt <- direct_deposit_deleg[deleg][ssnaddr][last_reward_cycle];
+buf_opt <- buff_deposit_deleg[deleg][ssnaddr][last2_reward_cycle];
+comb_opt = option_add cur_opt buf_opt;
+last_amt_o <- deleg_stake_per_cycle[deleg][ssnaddr][last_reward_cycle];
+last_amt = option_uint128_value last_amt_o;
+staking_of_deleg = match comb_opt with
+| Some stake => builtin add last_amt stake
+| None => last_amt
+end;
+no_rewards = builtin eq staking_of_deleg uint128_zero;
+match no_rewards with
+| True =>
+| False =>
 e = DelegHasUnwithdrawRewards;
 ThrowError e
+end
+| False =>
+e = DelegHasUnwithdrawRewards;
+ThrowError e
+end
 | False =>
 end
 end


### PR DESCRIPTION
To Unblock user from the special case:

1. user deposits buffered at cycle N
2. cannot move his delegate at cycle N + 1 even thought there is no rewards at all