### PR TITLE
fix: boost libs in CI after Scilla deps refactoring

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-18.04
         ocaml-version:
           - 4.08.1
 
@@ -33,11 +33,14 @@ jobs:
         with:
           ocaml-version: ${{ matrix.ocaml-version }}
 
+      - name: boost
+        run: sudo apt-get update && sudo apt-get install -yq libboost-system-dev libboost-test-dev
+
       - run: opam pin add scilla.dev git+https://github.com/Zilliqa/scilla\#master --no-action
 
       - run: opam depext scilla --yes
 
-      - run: opam install scilla
+      - run: opam install --verbose scilla
 
       - run: opam exec -- scilla-checker -gaslimit 10000 -libdir "$(opam var scilla:lib)/stdlib" contracts/gzil.scilla
       - if: ${{ always() }}


### PR DESCRIPTION
This is required after https://github.com/Zilliqa/scilla/pull/928 and several related PRs after that.