### PR TITLE
fix/remove-ssnrewardshare

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -9,8 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-18.04
+        os: [ubuntu-18.04, ubuntu-20.04]
         ocaml-version:
           - 4.08.1
 

--- a/README.md
+++ b/README.md
@@ -114,24 +114,7 @@ type Ssn =
 (*                     Address to be used to receive commission. *)
 ```
 
-2. SSNRewardShare Data Type:
-
-```ocaml
-type SsnRewardShare =
-| SsnRewardShare of ByStr20 Uint128
-``` 
-
-```ocaml
-(* SSNRewardShare has the following fields: *)
-
-(*  SSNAddress        : ByStr20 *)
-(*                      Address of the SSN. *)
-(*  RewardShare       : Uint128 *)
-(*                      This is the integer representation of the reward assigned by the verifier to this SSN for this cycle. *) 
-                        It's floor(NumberOfDSEpochsInCurrentCycle * 110,000 * VerificationPassed) *)
-```
-
-3. SsnStakeRewardShare Data Type:
+2. SsnStakeRewardShare Data Type:
 
 ```ocaml
 type SsnStakeRewardShare = 
@@ -146,7 +129,7 @@ type SsnStakeRewardShare =
 (*                      Total stake amount at a specific cycle.                                               *)
 ```
 
-4. SSNCycleInfo Data Type:
+3. SSNCycleInfo Data Type:
 
 ```ocaml
 type SSNCycleInfo =
@@ -160,7 +143,7 @@ type SSNCycleInfo =
 (*                                         Represents the total reward earned during this cycle for the given SSN. *)
 ```
 
-5. Error Data Type:
+4. Error Data Type:
 
 ```ocaml
 type Error =
@@ -278,7 +261,7 @@ Each of these category of transitions are presented in further detail below.
 
 | Name        | Params     | Description | Callable when paused? | Callable when not paused? |
 | ----------- | -----------|-------------|:--------------------------:|:--------------------------:|
-| `AssignStakeReward` | `ssnreward_list : List SsnRewardShare, available_reward : Uint128, initiator : ByStr20`| To assign reward to each SSN for this cycle. `ssnreward_list` contains the reward factor for each SSN. In more precise terms, it contains the value `(floor((NumberOfDSEpochsInCurrentCycle x 110,000 x VerificationPassed)))`. This input is then multiplied by `(floor(TotalStakeAtSSN / TotalStakeAcrossAllSSNs))` to compute the reward earned by each SSN. `initiator` is the verifier. The `available_reward` contains the rewards for all SSN as well as verifier. Post this call, any buffered deposit with any SSN must be converted to unbuffered stake deposit. The commission earned by the SSNs must also get updated.  | <center>:x:</center> | :heavy_check_mark: |
+| `AssignStakeReward` | `ssnreward_list : List (Pair ByStr20 Uint128), initiator : ByStr20`| To assign reward to each SSN for this cycle. `ssnreward_list` contains the reward factor for each SSN. In more precise terms, it contains the value `(floor((NumberOfDSEpochsInCurrentCycle x 110,000 x VerificationPassed)))`. This input is then multiplied by `(floor(TotalStakeAtSSN / TotalStakeAcrossAllSSNs))` to compute the reward earned by each SSN. `initiator` is the verifier. The `_amount` contains the rewards for all SSN as well as verifier. Post this call, any buffered deposit with any SSN must be converted to unbuffered stake deposit. The commission earned by the SSNs must also get updated.  | <center>:x:</center> | :heavy_check_mark: |
 
 ### Contract Upgrade Transitions
 
@@ -379,7 +362,7 @@ parameter `initiator` for the `SSNList` contract.
 |`WithdrawStakeAmt(ssnaddr: ByStr20, amt: Uint128)` | `WithdrawStakeAmt(ssnaddr: ByStr20, amt: Uint128, initiator : ByStr20)`|
 |`CompleteWithdrawal()` | `CompleteWithdrawal(initiator : ByStr20)`|
 |`ReDelegateStake(ssnaddr : ByStr20, to_ssn : ByStr20, amount : Uint128)` | `ReDelegateStake(ssnaddr : ByStr20, to_ssn : ByStr20, amount : Uint128, initiator : ByStr20)`|
-|`AssignStakeReward(ssnreward_list: List SsnRewardShare)` | `AssignStakeReward(ssnreward_list: List SsnRewardShare, initiator : ByStr20)`|
+|`AssignStakeReward(ssnreward_list: List (Pair ByStr20 Uint128))` | `AssignStakeReward(ssnreward_list: List (Pair ByStr20 Uint128), initiator : ByStr20)`|
 |`AddFunds()` | `AddFunds(initiator : ByStr20)`|
 |`AddSSNAfterUpgrade(ssnaddr: ByStr20, stake_amt: Uint128, rewards: Uint128, name: String, urlraw: String, urlapi: String, buff_deposit: Uint128,  comm: Uint128, comm_rewards: Uint128, rec_addr: ByStr20)` | `AddSSNAfterUpgrade(ssnaddr: ByStr20, stake_amt: Uint128, rewards: Uint128, name: String, urlraw: String, urlapi: String, buff_deposit: Uint128,  comm: Uint128, comm_rewards: Uint128, rec_addr: ByStr20, initiator : ByStr20)`|
 |`AddSSNAfterUpgrade(ssnaddr: ByStr20, stake_amt: Uint128, rewards: Uint128, name: String, urlraw: String, urlapi: String, buff_deposit: Uint128,  comm: Uint128, comm_rewards: Uint128, rec_addr: ByStr20)` | `AddSSNAfterUpgrade(ssnaddr: ByStr20, stake_amt: Uint128, rewards: Uint128, name: String, urlraw: String, urlapi: String, buff_deposit: Uint128,  comm: Uint128, comm_rewards: Uint128, rec_addr: ByStr20, initiator : ByStr20)`|

--- a/contracts/proxy.scilla
+++ b/contracts/proxy.scilla
@@ -9,9 +9,6 @@ let one_msg =
     let e = Nil {Message} in
     Cons {Message} m e
 
-type SsnRewardShare =
-| SsnRewardShare of ByStr20 Uint128
-
 type SSNCycleInfo =
 | SSNCycleInfo of Uint128 Uint128
 (***************************************************)
@@ -259,7 +256,7 @@ end
 (***************************************************)
 
 (* @dev: Assign stake reward to all ssn from ssnlist. Used by verifier only. *)
-(* @param ssnrewardlist: List of SsnRewardShare *)
+(* @param ssnrewardlist: List of ssnreward. Each ssnreward is a Pair ssn_address cycle_reward *)
 transition AssignStakeReward(ssnreward_list: List (Pair ByStr20 Uint128))
     current_impl <- implementation;
     accept;

--- a/contracts/proxy.scilla
+++ b/contracts/proxy.scilla
@@ -260,7 +260,7 @@ end
 
 (* @dev: Assign stake reward to all ssn from ssnlist. Used by verifier only. *)
 (* @param ssnrewardlist: List of SsnRewardShare *)
-transition AssignStakeReward(ssnreward_list: List SsnRewardShare)
+transition AssignStakeReward(ssnreward_list: List (Pair ByStr20 Uint128))
     current_impl <- implementation;
     accept;
     msg = {_tag: "AssignStakeReward"; _recipient: current_impl; _amount: _amount; ssnreward_list: ssnreward_list; initiator: _sender};

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -35,20 +35,6 @@ library SSNList
 type Ssn =
 | Ssn of Bool Uint128 Uint128 String String String Uint128 Uint128 Uint128 ByStr20
 
-(* SSNRewardShare Data Type *)
-(* SSNRewardShare has the following fields: *)
-(* CycleReward is in Qa *)
-
-(*  SSNAddress        : ByStr20 *)
-(*                      Address of the SSN. *)
-(*  CycleReward       : Uint128 *)
-(*                      Integer representation of reward assigned by the verifier to this SSN for this cycle. *)
-(*                      It's floor(NumberOfDSEpochsInCurrentCycle * 110,000 * VerificationPassed) *)
-(* https://github.com/Zilliqa/ZIP/blob/zip-11-author-fix/zips/zip-11.md#verifier *)
-
-type SsnRewardShare =
-| SsnRewardShare of ByStr20 Uint128
-
 (*  SSNAddress        : ByStr20 *)
 (*                      Address of the SSN. *)
 (*  CycleReward       : Uint128 *)

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -205,9 +205,9 @@ let muldiv : Uint128 -> Uint128 -> Uint128 -> Uint128 =
 
 let map_to_stake_rewards = 
   fun (total_stake: Uint128) =>
-  fun (element: SsnRewardShare) =>
+  fun (element: Pair ByStr20 Uint128) =>
     match element with
-    | SsnRewardShare ssnaddr cycle_reward => SsnStakeRewardShare ssnaddr cycle_reward total_stake 
+    | Pair ssnaddr cycle_reward => SsnStakeRewardShare ssnaddr cycle_reward total_stake 
     end
 
 let bool_active = True
@@ -1317,9 +1317,14 @@ end
 (***************************************************)
 
 (* @dev: Assign stake reward to all ssn from ssnlist. Used by verifier only. *)
-(* @param ssnrewardlist: List of SsnRewardShare *)
+(* @param ssnrewardlist: List of SSN address and cycle rewards in Qa *)
+(*  CycleReward       : Uint128 *)
+(*                      Integer representation of reward assigned by the verifier to this SSN for this cycle. *)
+(*                      It's floor(NumberOfDSEpochsInCurrentCycle * 110,000 * VerificationPassed) *)
+(* https://github.com/Zilliqa/ZIP/blob/zip-11-author-fix/zips/zip-11.md#verifier *)
+
 (* @param initiator: The original caller who called the proxy *)
-transition AssignStakeReward(ssnreward_list: List SsnRewardShare, initiator: ByStr20)
+transition AssignStakeReward(ssnreward_list: List (Pair ByStr20 Uint128), initiator: ByStr20)
   IsNotPaused;
   IsProxy;
   CallerIsVerifier initiator;
@@ -1333,7 +1338,7 @@ transition AssignStakeReward(ssnreward_list: List SsnRewardShare, initiator: ByS
   total_stake_amt <- totalstakeamount;
   f = map_to_stake_rewards total_stake_amt;
 
-  mapper = @list_map SsnRewardShare SsnStakeRewardShare;
+  mapper = @list_map (Pair ByStr20 Uint128) SsnStakeRewardShare;
   ssn_stake_reward_list = mapper f ssnreward_list;
   forall ssn_stake_reward_list UpdateStakeReward;
   verifier_reward_amt <- verifier_reward;

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -1307,7 +1307,7 @@ end
 (*  CycleReward       : Uint128 *)
 (*                      Integer representation of reward assigned by the verifier to this SSN for this cycle. *)
 (*                      It's floor(NumberOfDSEpochsInCurrentCycle * 110,000 * VerificationPassed) *)
-(* https://github.com/Zilliqa/ZIP/blob/zip-11-author-fix/zips/zip-11.md#verifier *)
+(* https://github.com/Zilliqa/ZIP/blob/master/zips/zip-11.md#verifier *)
 
 (* @param initiator: The original caller who called the proxy *)
 transition AssignStakeReward(ssnreward_list: List (Pair ByStr20 Uint128), initiator: ByStr20)

--- a/tests/ssnlist.scilla
+++ b/tests/ssnlist.scilla
@@ -3,8 +3,6 @@ import ListUtils IntUtils
 library SSNList
 type Ssn =
 | Ssn of Bool Uint128 Uint128 String String String Uint128 Uint128 Uint128 ByStr20
-type SsnRewardShare =
-| SsnRewardShare of ByStr20 Uint128
 type SsnStakeRewardShare =
 | SsnStakeRewardShare of ByStr20 Uint128 Uint128
 type SSNCycleInfo =
@@ -123,9 +121,9 @@ res128
 end
 let map_to_stake_rewards =
 fun (total_stake: Uint128) =>
-fun (element: SsnRewardShare) =>
+fun (element: Pair ByStr20 Uint128) =>
 match element with
-| SsnRewardShare ssnaddr cycle_reward => SsnStakeRewardShare ssnaddr cycle_reward total_stake
+| Pair ssnaddr cycle_reward => SsnStakeRewardShare ssnaddr cycle_reward total_stake
 end
 let bool_active = True
 let bool_inactive = False
@@ -991,7 +989,7 @@ msg = one_msg msg_to_delegator;
 send msg
 end
 end
-transition AssignStakeReward(ssnreward_list: List SsnRewardShare, initiator: ByStr20)
+transition AssignStakeReward(ssnreward_list: List (Pair ByStr20 Uint128), initiator: ByStr20)
 IsNotPaused;
 IsProxy;
 CallerIsVerifier initiator;
@@ -1002,7 +1000,7 @@ lastrewardcycle := newLastRewardCycleNum;
 verifier_reward := _amount;
 total_stake_amt <- totalstakeamount;
 f = map_to_stake_rewards total_stake_amt;
-mapper = @list_map SsnRewardShare SsnStakeRewardShare;
+mapper = @list_map (Pair ByStr20 Uint128) SsnStakeRewardShare;
 ssn_stake_reward_list = mapper f ssnreward_list;
 forall ssn_stake_reward_list UpdateStakeReward;
 verifier_reward_amt <- verifier_reward;


### PR DESCRIPTION
## Description
This pr is a fix for a scilla bug which causes custom ADT not to be interpreted when used as a parameter. The pr replaces the `SsnRewardShare (ByStr20 Uint128)` ADT with `Pair ByStr20 Uint128`. Specifically, it replaces the existing `List SsnRewardShare` to `List (Pair ByStr20 Uint128)` for `proxy.scilla` and `ssnlist.scilla`.

## Affected Transition
`AssignStakeReward`

## Notes
This pr is a series of improvements as part of [ZIP-19 (WIP)](https://github.com/Zilliqa/ZIP/blob/feat/zip19/zips/zip-19.md)