### PR TITLE
fix/refactor-swap-deleg

### DIFF
--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -2235,8 +2235,7 @@ procedure SwapDirectDeposit(ssninfo: Pair ByStr20 Ssn)
       current_ssn := ssn;
       forall direct_deposit_list ActualSwapDirectDeposit;
       (* delete after add operation *)
-      delete direct_deposit_deleg[deleg][ssn_address];
-      CleanDirectDepositDelegAddr deleg
+      delete direct_deposit_deleg[deleg][ssn_address]
     | None => (* No direct deposit at this ssn *)
     end
   | None => (* not possible to have no existing deleg *)
@@ -2302,8 +2301,7 @@ procedure SwapDelegStakePerCycle(ssninfo: Pair ByStr20 Ssn)
       current_ssn := ssn;
       forall deleg_stake_per_cycle_list ActualSwapDelegStakePerCycle;
       (* delete after add operation *)
-      delete deleg_stake_per_cycle[deleg][ssn_address];
-      CleanDelegStakePerCycleDelegAddr deleg
+      delete deleg_stake_per_cycle[deleg][ssn_address]
     | None => (* No deposit at this ssn *)
     end
   | None => (* not possible to have no existing deleg *)
@@ -2331,7 +2329,6 @@ procedure SwapDepositAmtDeleg(ssninfo: Pair ByStr20 Ssn)
           new_amt = builtin add existing_deposit_amt deposit_amt;
           deposit_amt_deleg[new_deleg_addr][ssn_address] := new_amt;
           delete deposit_amt_deleg[initial_deleg][ssn_address];
-          CleanDepositAmtDelegAddr initial_deleg;
           e = { _eventname: "SwapDepositAmtDelegExists"; initial_deleg: initial_deleg; new_deleg: new_deleg_addr; ssn_addr: ssn_address; existing_amt: existing_deposit_amt; transferred_amt: deposit_amt; new_amt: new_amt };
           event e
         | None =>
@@ -2339,7 +2336,6 @@ procedure SwapDepositAmtDeleg(ssninfo: Pair ByStr20 Ssn)
           (* take amount from current deleg and give to new deleg *)
           deposit_amt_deleg[new_deleg_addr][ssn_address] := deposit_amt;
           delete deposit_amt_deleg[initial_deleg][ssn_address];
-          CleanDepositAmtDelegAddr initial_deleg;
           e = { _eventname: "SwapDepositAmtDelegNewEntry"; initial_deleg: initial_deleg; new_deleg: new_deleg_addr; ssn_addr: ssn_address; amt: deposit_amt };
           event e
         end
@@ -2412,14 +2408,12 @@ procedure SwapLastWithdrawCycleDeleg(ssninfo: Pair ByStr20 Ssn)
           (* don't replace; already assert no buffered deposit and rewards for both requestor and new_deleg  *)
           (* requestor lwcd should be similar to new_deleg lwcd *)
           delete last_withdraw_cycle_deleg[initial_deleg][ssn_address];
-          CleanLastWithdrawCycleDelegAddr initial_deleg;
           e = { _eventname: "SwapLastWithdrawCycleDelegExists"; initial_deleg: initial_deleg; new_deleg: new_deleg_addr; ssn_addr: ssn_address; existing_lwcd: existing_lwcd };
           event e
         | None =>
           (* new deleg has no last withdraw cycle for this ssn *)
           last_withdraw_cycle_deleg[new_deleg_addr][ssn_address] := requestor_lwcd;
           delete last_withdraw_cycle_deleg[initial_deleg][ssn_address];
-          CleanLastWithdrawCycleDelegAddr initial_deleg;
           e = { _eventname: "SwapLastWithdrawCycleDelegNewEntry"; initial_deleg: initial_deleg; new_deleg: new_deleg_addr; ssn_addr: ssn_address; lwcd: requestor_lwcd };
           event e
         end
@@ -2453,14 +2447,12 @@ procedure SwapLastBuffDepositCycleDeleg(ssninfo: Pair ByStr20 Ssn)
           (* new deleg has delegate same ssn as requestor *)
           (* don't replace; already assert no buffered deposit and rewards for both requestor and new_deleg  *)
           delete last_buf_deposit_cycle_deleg[initial_deleg][ssn_address];
-          CleanLastBuffDepositCycleDelegAddr initial_deleg;
           e = { _eventname: "SwapLastBuffDepositCycleDelegExists"; initial_deleg: initial_deleg; new_deleg: new_deleg_addr; ssn_addr: ssn_address; existing_lbdc: existing_lbdc };
           event e
         | None =>
           (* new deleg has no last buff deposit for this ssn *)
           last_buf_deposit_cycle_deleg[new_deleg_addr][ssn_address] := requestor_lbdc;
           delete last_buf_deposit_cycle_deleg[initial_deleg][ssn_address];
-          CleanLastBuffDepositCycleDelegAddr initial_deleg;
           e = { _eventname: "SwapLastBuffDepositCycleDelegNewEntry"; initial_deleg: initial_deleg; new_deleg: new_deleg_addr; ssn_addr: ssn_address; lbdc: requestor_lbdc };
           event e
         end
@@ -2652,6 +2644,12 @@ transition ConfirmDelegatorSwap(requestor: ByStr20, initiator: ByStr20)
   AssertNoBufferedAndRewards initiator;
   SwapDelegator requestor initiator;
   SwapCleanUp;
+  (* delete the requestor's deleg key from these maps; requestor's ssnaddr key already deleted in the Swap proc *)
+  CleanDirectDepositDelegAddr requestor;
+  CleanDelegStakePerCycleDelegAddr requestor;
+  CleanDepositAmtDelegAddr requestor;
+  CleanLastWithdrawCycleDelegAddr requestor;
+  CleanLastBuffDepositCycleDelegAddr requestor;
   delete deleg_swap_request[requestor];
   e = { _eventname: "ConfirmDelegatorSwap"; initial_deleg: requestor; new_deleg: initiator };
   event e

--- a/contracts/ssnlist.scilla
+++ b/contracts/ssnlist.scilla
@@ -2220,9 +2220,9 @@ end
 
 (* @dev Swap deleg address from current_deleg -> new_deleg in direct_deposit_deleg *)
 (* @see ActualSwapDirectDeposit *)
-procedure SwapDirectDeposit(ssninfo: Pair ByStr20 Ssn)
-  fst = @fst ByStr20 Ssn;
-  ssn_address = fst ssninfo;
+procedure SwapDirectDeposit(ssndeposit: Pair ByStr20 Uint128)
+  fst = @fst ByStr20 Uint128;
+  ssn_address = fst ssndeposit;
   current_deleg_o <- current_deleg;
 
   match current_deleg_o with
@@ -2286,9 +2286,9 @@ end
 
 (* @dev Swap deleg address from current_deleg -> new_deleg in deleg_stake_cycle *)
 (* @see ActualSwapDelegStakePerCycle *)
-procedure SwapDelegStakePerCycle(ssninfo: Pair ByStr20 Ssn)
-  fst = @fst ByStr20 Ssn;
-  ssn_address = fst ssninfo;
+procedure SwapDelegStakePerCycle(ssndeposit: Pair ByStr20 Uint128)
+  fst = @fst ByStr20 Uint128;
+  ssn_address = fst ssndeposit;
   current_deleg_o <- current_deleg;
 
   match current_deleg_o with
@@ -2309,9 +2309,9 @@ procedure SwapDelegStakePerCycle(ssninfo: Pair ByStr20 Ssn)
 end
 
 (* @dev Swap deleg address from current_deleg -> new_deleg in deposit_amt_deleg *)
-procedure SwapDepositAmtDeleg(ssninfo: Pair ByStr20 Ssn)
-  fst = @fst ByStr20 Ssn;
-  ssn_address = fst ssninfo;
+procedure SwapDepositAmtDeleg(ssndeposit: Pair ByStr20 Uint128)
+  fst = @fst ByStr20 Uint128;
+  ssn_address = fst ssndeposit;
   current_deleg_o <- current_deleg;
   new_deleg_o <- new_deleg;
 
@@ -2348,9 +2348,9 @@ procedure SwapDepositAmtDeleg(ssninfo: Pair ByStr20 Ssn)
 end
 
 (* @dev Swap deleg address from current_deleg -> new_deleg in ssn_deleg_amt *)
-procedure SwapSSNDelegAmt(ssninfo: Pair ByStr20 Ssn)
-  fst = @fst ByStr20 Ssn;
-  ssn_address = fst ssninfo;
+procedure SwapSSNDelegAmt(ssndeposit: Pair ByStr20 Uint128)
+  fst = @fst ByStr20 Uint128;
+  ssn_address = fst ssndeposit;
   current_deleg_o <- current_deleg;
   new_deleg_o <- new_deleg;
 
@@ -2388,9 +2388,9 @@ end
 (* @dev Swap deleg address from current_deleg -> new_deleg in last_withdraw_cycle_deleg *)
 (* Both parties have been asserted to have no buffered deposits or rewards; lwcd should be identical or one-off lrc *)
 (* If current_deleg and new_deleg has same ssn, don't replace new_deleg entry *)
-procedure SwapLastWithdrawCycleDeleg(ssninfo: Pair ByStr20 Ssn)
-  fst = @fst ByStr20 Ssn;
-  ssn_address = fst ssninfo;
+procedure SwapLastWithdrawCycleDeleg(ssndeposit: Pair ByStr20 Uint128)
+  fst = @fst ByStr20 Uint128;
+  ssn_address = fst ssndeposit;
   current_deleg_o <- current_deleg;
   new_deleg_o <- new_deleg;
 
@@ -2428,9 +2428,9 @@ end
 (* @dev Swap deleg address from current_deleg -> new_deleg in last_buf_deposit_cycle_deleg *)
 (* Both parties have been asserted to have no buffered deposits or rewards; lbdc should be identical or one-off lrc *)
 (* If current_deleg and new_deleg has same ssn, don't replace new_deleg entry *)
-procedure SwapLastBuffDepositCycleDeleg(ssninfo: Pair ByStr20 Ssn)
-  fst = @fst ByStr20 Ssn;
-  ssn_address = fst ssninfo;
+procedure SwapLastBuffDepositCycleDeleg(ssndeposit: Pair ByStr20 Uint128)
+  fst = @fst ByStr20 Uint128;
+  ssn_address = fst ssndeposit;
   current_deleg_o <- current_deleg;
   new_deleg_o <- new_deleg;
 
@@ -2508,16 +2508,21 @@ procedure SwapDelegator(requestor: ByStr20, new_deleg_addr: ByStr20)
   current_deleg := c;
   n = Some {ByStr20} new_deleg_addr;
   new_deleg := n;
-  ssnlist_o <- ssnlist;
-  ssninfo_list = builtin to_list ssnlist_o;
 
-  (* swap *)
-  forall ssninfo_list SwapDirectDeposit;
-  forall ssninfo_list SwapDelegStakePerCycle;
-  forall ssninfo_list SwapDepositAmtDeleg;
-  forall ssninfo_list SwapSSNDelegAmt;
-  forall ssninfo_list SwapLastBuffDepositCycleDeleg;
-  forall ssninfo_list SwapLastWithdrawCycleDeleg;
+  (* get the list of requestor's ssn *)
+  ssn_deposit_map <- deposit_amt_deleg[requestor];
+  match ssn_deposit_map with
+   | Some ssn_deposit_entry =>
+     ssn_deposit_list = builtin to_list ssn_deposit_entry;
+     (* swap *)
+     forall ssn_deposit_list SwapDirectDeposit;
+     forall ssn_deposit_list SwapDelegStakePerCycle;
+     forall ssn_deposit_list SwapDepositAmtDeleg;
+     forall ssn_deposit_list SwapSSNDelegAmt;
+     forall ssn_deposit_list SwapLastBuffDepositCycleDeleg;
+     forall ssn_deposit_list SwapLastWithdrawCycleDeleg
+   | None => (* nothing to swap *)
+  end;
   
   (* swap pending withdrawal *)
   match c with
@@ -2585,10 +2590,10 @@ procedure IsValidSwapAddr(requestor: ByStr20, new_deleg_addr: ByStr20)
   end
 end
 
-procedure AssertSwapNoBufferedAndRewards(ssninfo: Pair ByStr20 Ssn)
+procedure AssertSwapNoBufferedAndRewards(ssndeposit: Pair ByStr20 Uint128)
   current_deleg_o <- current_deleg;
-  fst = @fst ByStr20 Ssn;
-  ssn_address = fst ssninfo;
+  fst = @fst ByStr20 Uint128;
+  ssn_address = fst ssndeposit;
   ssn_o <- ssnlist[ssn_address];
 
   match ssn_o with
@@ -2608,9 +2613,14 @@ end
 procedure AssertNoBufferedAndRewards(requestor : ByStr20)
   c = Some {ByStr20} requestor;
   current_deleg := c;
-  ssnlist_o <- ssnlist;
-  ssninfo_list = builtin to_list ssnlist_o;
-  forall ssninfo_list AssertSwapNoBufferedAndRewards
+  (* get the list of requestor's ssn *)
+  ssn_deposit_map <- deposit_amt_deleg[requestor];
+  match ssn_deposit_map with
+   | Some ssn_deposit_entry =>
+     ssn_deposit_list = builtin to_list ssn_deposit_entry;
+     forall ssn_deposit_list AssertSwapNoBufferedAndRewards
+   | None =>
+  end
 end
 
 (* @dev: Creates a request to another delegator to indicate interest in transferring all stakes, rewards etc to the delegator *)


### PR DESCRIPTION
- shift all the `CleanMapName requestor` from inside the swap for-loops to outside
- use `deposit_amt_deleg` instead of `ssnlist` to fetch the list of ssn addresses that a requestor and new delegator have staked with
- reduce overall txn fee during swapping from [6.8 ZIL](https://devex.zilliqa.com/tx/0e2fa74d5333a72aa4505bf31a8e7efc5c84f84ff8e066f0988e20d125acc97e?network=https%3A%2F%2Fzilliqa-isolated-server.zilliqa.com) to [5 ZIL](https://devex.zilliqa.com/tx/0xf42ccd230059fe5d7573682734a3d4470235f3c8d64bc3e648b58902ae698519?network=https%3A%2F%2Fzilliqa-isolated-server.zilliqa.com)